### PR TITLE
Raise KeyError when invalid param is requested

### DIFF
--- a/cads_processing_api_service/constraints.py
+++ b/cads_processing_api_service/constraints.py
@@ -141,8 +141,12 @@ def get_possible_values(
                 if len(selected_values & combination[field_name]) == 0:
                     ok = False
                     break
-            else:
+            elif field_name in form.keys():
                 ok = False
+                break
+            else:
+                print(f'Error: invalid param "{field_name}"')
+                raise KeyError
         if ok:
             for field_name, valid_values in combination.items():
                 result[field_name] |= set(valid_values)


### PR DESCRIPTION
```
form = {"level": {"500"}, "time": {"12:00", "00:00"}, "param": {"Z", "T"}, "product_type": {"mean"},}

constraints = [
    {"level": {"500"}, "param": {"Z", "T"}, "time": {"12:00", "00:00"}},
    {"level": {"500", "850"}, "param": {"Z", "T"}, "product_type": {"mean"}},
]

cads_processing_api_service.constraints.apply_constraints(form, {"invalid_key":{"500"}}, constraints)
``` 

Will now raise:

```

Error: invalid param "invalid_key"
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
``` 
