### PR TITLE
add request field to job info

### DIFF
--- a/cads_processing_api_service/models.py
+++ b/cads_processing_api_service/models.py
@@ -30,6 +30,11 @@ class Execute(ogc_api_processes_fastapi.models.Execute):
 
 
 class StatusInfo(ogc_api_processes_fastapi.models.StatusInfo):
+    request: dict[
+        str,
+        ogc_api_processes_fastapi.models.InlineOrRefData
+        | list[ogc_api_processes_fastapi.models.InlineOrRefData],
+    ]
     results: dict[str, Any] | None = None
 
 

--- a/cads_processing_api_service/utils.py
+++ b/cads_processing_api_service/utils.py
@@ -419,8 +419,7 @@ def submit_job(
         process_id=process_id,
         **job_kwargs,
     )
-
-    status_info = ogc_api_processes_fastapi.models.StatusInfo(
+    status_info = models.StatusInfo(
         processID=job["process_id"],
         type="process",
         jobID=job["request_uid"],
@@ -429,6 +428,7 @@ def submit_job(
         started=job["started_at"],
         finished=job["finished_at"],
         updated=job["updated_at"],
+        request=job["request_body"]["kwargs"]["request"],
     )
 
     return status_info
@@ -524,6 +524,7 @@ def make_status_info(
         started=job["started_at"],
         finished=job["finished_at"],
         updated=job["updated_at"],
+        request=job["request_body"]["kwargs"]["request"],
     )
     if add_results:
         results = None

--- a/tests/integration_test_10_clients.py
+++ b/tests/integration_test_10_clients.py
@@ -25,47 +25,47 @@ NON_EXISTING_PROCESS_ID = "non-existing-dataset"
 NON_EXISTING_JOB_ID = "1234"
 POST_PROCESS_REQUEST_BODY_SUCCESS = {
     "inputs": {
-        "product_type": "reanalysis",
+        "product_type": ["reanalysis"],
         "format": "grib",
-        "variable": "temperature",
-        "pressure_level": "1",
-        "year": "1971",
-        "month": "01",
-        "day": "25",
-        "time": "06:00",
+        "variable": ["temperature"],
+        "pressure_level": ["1"],
+        "year": ["1971"],
+        "month": ["01"],
+        "day": ["25"],
+        "time": ["06:00"],
     }
 }
 POST_PROCESS_REQUEST_BODY_SUCCESS_W_LICENCES = {
     "inputs": {
-        "product_type": "reanalysis",
-        "format": "grib",
-        "variable": "temperature",
-        "pressure_level": "1",
-        "year": "1971",
-        "month": "01",
-        "day": "25",
-        "time": "06:00",
+        "product_type": ["reanalysis"],
+        "format": ["grib"],
+        "variable": ["temperature"],
+        "pressure_level": ["1"],
+        "year": ["1971"],
+        "month": ["01"],
+        "day": ["25"],
+        "time": ["06:00"],
     },
     "acceptedLicences": [{"id": "licence-to-use-copernicus-products", "revision": 12}],
 }
 POST_PROCESS_REQUEST_BODY_FAIL = {
     "inputs": {
-        "product_type": "non-existing-product-type",
-        "format": "grib",
-        "variable": "temperature",
-        "pressure_level": "1",
-        "year": "1971",
-        "month": "01",
-        "day": "25",
-        "time": "06:00",
+        "product_type": ["non-existing-product-type"],
+        "format": ["grib"],
+        "variable": ["temperature"],
+        "pressure_level": ["1"],
+        "year": ["1971"],
+        "month": ["01"],
+        "day": ["25"],
+        "time": ["06:00"],
     }
 }
 POST_PROCESS_REQUEST_BODY_SLOW = {
     "inputs": {
-        "product_type": "reanalysis",
+        "product_type": ["reanalysis"],
         "format": "grib",
-        "variable": "temperature",
-        "pressure_level": "1",
+        "variable": ["temperature"],
+        "pressure_level": ["1"],
         "year": [f"{year}" for year in range(1959, 2022)],
         "month": [f"{month:02}" for month in range(1, 13)],
         "day": [f"{day:02}" for day in range(1, 32)],
@@ -260,14 +260,15 @@ def test_post_process_execution_stored_accepted_licences(
         "created",
         "updated",
         "links",
+        "request",
     )
     assert all([key in response_body for key in exp_keys])
-
     exp_process_id = EXISTING_PROCESS_ID
     assert response_body["processID"] == exp_process_id
-
     exp_status = "accepted"
     assert response_body["status"] == exp_status
+    exp_request = POST_PROCESS_REQUEST_BODY_SUCCESS["inputs"]
+    assert response_body["request"] == exp_request
 
     response = delete_job(
         dev_env_proc_api_url,
@@ -311,27 +312,9 @@ def test_post_process_execution_anon_user(
     exp_status_code = 201
     assert response_status_code == exp_status_code
 
-    response_body = response.json()
-    exp_keys = (
-        "processID",
-        "type",
-        "jobID",
-        "status",
-        "created",
-        "updated",
-        "links",
-    )
-    assert all([key in response_body for key in exp_keys])
-
-    exp_process_id = EXISTING_PROCESS_ID
-    assert response_body["processID"] == exp_process_id
-
-    exp_status = "accepted"
-    assert response_body["status"] == exp_status
-
     response = delete_job(
         dev_env_proc_api_url,
-        response_body["jobID"],
+        response.json()["jobID"],
         auth_headers=AUTH_HEADERS_VALID_ANON,
     )
 
@@ -426,10 +409,13 @@ def test_get_job(dev_env_proc_api_url: str, dev_env_prof_api_url: str) -> None:
         "created",
         "updated",
         "links",
+        "request",
     )
     assert all([key in response_body for key in exp_keys])
     exp_status = ("accepted", "running", "successful")
     assert response_body["status"] in exp_status
+    exp_request = POST_PROCESS_REQUEST_BODY_SUCCESS["inputs"]
+    assert response_body["request"] == exp_request
 
     response = delete_job(dev_env_proc_api_url, job_id)
 
@@ -458,10 +444,10 @@ def test_get_job_successful(
             "updated",
             "finished",
             "links",
+            "request",
             "results",
         )
         assert all([key in response_body for key in exp_keys])
-
         exp_results_link = {
             "href": f"{request_url}/results",
             "rel": "results",

--- a/tests/test_30_utils.py
+++ b/tests/test_30_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest.mock
+from typing import Any
 
 import cads_broker
 import ogc_api_processes_fastapi.exceptions
@@ -323,7 +324,7 @@ def test_get_results_from_broker_db() -> None:
 
 
 def test_make_status_info() -> None:
-    job = {
+    job: dict[str, Any] = {
         "status": "running",
         "request_uid": "1234",
         "process_id": "1234",
@@ -331,6 +332,7 @@ def test_make_status_info() -> None:
         "started_at": "2023-01-01T16:20:12.175021",
         "finished_at": "2023-01-01T16:20:12.175021",
         "updated_at": "2023-01-01T16:20:12.175021",
+        "request_body": {"kwargs": {"request": {"product_type": ["reanalysis"]}}},
     }
     mock_session = unittest.mock.Mock(spec=sqlalchemy.orm.Session)
     status_info = utils.make_status_info(job, session=mock_session, add_results=False)
@@ -343,6 +345,7 @@ def test_make_status_info() -> None:
         started=job["started_at"],
         finished=job["finished_at"],
         updated=job["updated_at"],
+        request=job["request_body"]["kwargs"]["request"],
     )
     assert status_info == exp_status_info
 


### PR DESCRIPTION
This PR adds a `request` field to all StatusInfo responses, containing inputs of the executing process.