### PR TITLE
Refactor custom metrics

### DIFF
--- a/cads_processing_api_service/main.py
+++ b/cads_processing_api_service/main.py
@@ -31,7 +31,7 @@ app.router.add_api_route(
     constraints.validate_constraints,
     methods=["POST"],
 )
-app.add_route("/metrics", metrics.handle_metrics)
+app.router.add_api_route("/metrics", metrics.handle_metrics)
 app.add_middleware(starlette_exporter.middleware.PrometheusMiddleware)
 
 # FIXME: temporary workaround

--- a/cads_processing_api_service/metrics.py
+++ b/cads_processing_api_service/metrics.py
@@ -21,9 +21,7 @@ def handle_metrics(
         dependencies.get_compute_session
     ),
 ) -> starlette.responses.Response:
-    accepted_request = cads_broker.database.count_accepted_requests_in_session(
-        compute_session
+    GAUGE.labels("queue").set(
+        cads_broker.database.count_accepted_requests_in_session(compute_session)
     )
-    raise ValueError(accepted_request)
-    GAUGE.labels("queue").set(accepted_request)
     return starlette_exporter.handle_metrics(request)


### PR DESCRIPTION
Hi @suarezePredictia, while fixing some issues related to the creation of database sessions I had to refactor the `metrics.py` code.

FYI, the main issue there was that using the `cads_broker.count_accepted_request` method a new sessionmaker sqlalchemy object (i.e. a new connection pool) was created at each call, thus actually not exploiting correctly the connection pooling feature. The general way to go should be to create a unique sessionmaker object and then instantiate all database sessions from it.

Also, I changed from using a middleware which performed the counting operation only when the `/metrics` route was called, to performing the count operation in a new (custom) `handle_metrics` endpoint for the `/metrics` route.