### PR TITLE
log in stdout and add correct format for fluentd

### DIFF
--- a/cads_processing_api_service/config.py
+++ b/cads_processing_api_service/config.py
@@ -19,6 +19,7 @@ Options are based on pydantic.BaseSettings, so they automatically get values fro
 
 import json
 import logging
+import sys
 from typing import Any, Callable, Mapping, MutableMapping
 
 import pydantic
@@ -89,6 +90,8 @@ def configure_logger() -> None:
     """
     logging.basicConfig(
         level=logging.INFO,
+        format="%(message)s",
+        stream=sys.stdout,
     )
 
     structlog.configure(


### PR DESCRIPTION
fluentd is not able to parse the log message if there is an additional string at the beginning of every log message. 
This PR convert such log messages:
```
INFO:cads_processing_api_service.clients:{"event": "Posting process execution", "user_id": -1, "execution_content": {"
inputs": {}, "outputs": null, "response": "<Response.raw: 'raw'>", "subscriber": null, "acceptedLicences": []}, "trace
_id": "858c739a-d88a-426d-b5a0-db2420cf8ffe", "logger": "cads_processing_api_service.clients", "level": "info", "user_
request": true, "timestamp": "2023-02-09 10:25.23"}
```
into
```
{"event": "Posting process execution", "user_id": -1, "execution_content": {"
inputs": {}, "outputs": null, "response": "<Response.raw: 'raw'>", "subscriber": null, "acceptedLicences": []}, "trace
_id": "858c739a-d88a-426d-b5a0-db2420cf8ffe", "logger": "cads_processing_api_service.clients", "level": "info", "user_
request": true, "timestamp": "2023-02-09 10:25.23"}
```