### PR TITLE
add resources keyword to create_request

### DIFF
--- a/cads_processing_api_service/adaptors.py
+++ b/cads_processing_api_service/adaptors.py
@@ -58,6 +58,7 @@ def make_system_job_kwargs(
         config = {}
 
     entry_point = config.pop("entry_point", FALLBACK_ENTRY_POINT)
+    resources = config.pop("resources", {})
 
     setup_code = resource.adaptor
     if setup_code is None:
@@ -78,6 +79,7 @@ def make_system_job_kwargs(
     job_kwargs: dict[str, Any] = {
         "setup_code": setup_code,
         "entry_point": entry_point,
+        "resources": resources,
         "kwargs": kwargs,
     }
 


### PR DESCRIPTION
I've already added the `resources` keyword to `cads_broker.database`.