### PR TITLE
remove dependancy on cads-adaptors directory structure

### DIFF
--- a/cads_processing_api_service/adaptors.py
+++ b/cads_processing_api_service/adaptors.py
@@ -82,7 +82,7 @@ def make_system_job_kwargs(
 
 def instantiate_adaptor(
     dataset: cads_catalogue.database.Resource,
-) -> cads_adaptors.adaptor.AbstractAdaptor:
+) -> cads_adaptors.AbstractAdaptor:
     adaptor_properties = get_adaptor_properties(dataset)
     adaptor_class = cads_adaptors.get_adaptor_class(
         entry_point=adaptor_properties["entry_point"],

--- a/cads_processing_api_service/constraints.py
+++ b/cads_processing_api_service/constraints.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-import cads_adaptors.adaptor
+from cads_adaptors import AbstractAdaptor
 import cads_adaptors.constraints
 import cads_catalogue
 import fastapi
@@ -16,7 +16,7 @@ def apply_constraints(
     catalogue_sessionmaker = db_utils.get_catalogue_sessionmaker()
     with catalogue_sessionmaker() as catalogue_session:
         dataset = utils.lookup_resource_by_id(process_id, record, catalogue_session)
-    adaptor: cads_adaptors.adaptor.AbstractAdaptor = adaptors.instantiate_adaptor(
+    adaptor: AbstractAdaptor = adaptors.instantiate_adaptor(
         dataset
     )
     try:

--- a/cads_processing_api_service/constraints.py
+++ b/cads_processing_api_service/constraints.py
@@ -1,9 +1,9 @@
 from typing import Any
 
+import cads_adaptors
 import cads_adaptors.constraints
 import cads_catalogue
 import fastapi
-from cads_adaptors import AbstractAdaptor
 
 from . import adaptors, db_utils, exceptions, utils
 
@@ -16,7 +16,7 @@ def apply_constraints(
     catalogue_sessionmaker = db_utils.get_catalogue_sessionmaker()
     with catalogue_sessionmaker() as catalogue_session:
         dataset = utils.lookup_resource_by_id(process_id, record, catalogue_session)
-    adaptor: AbstractAdaptor = adaptors.instantiate_adaptor(dataset)
+    adaptor: cads_adaptors.AbstractAdaptor = adaptors.instantiate_adaptor(dataset)
     try:
         constraints = adaptor.apply_constraints(request=request)
     except cads_adaptors.constraints.ParameterError as exc:

--- a/cads_processing_api_service/constraints.py
+++ b/cads_processing_api_service/constraints.py
@@ -1,9 +1,9 @@
 from typing import Any
 
-from cads_adaptors import AbstractAdaptor
 import cads_adaptors.constraints
 import cads_catalogue
 import fastapi
+from cads_adaptors import AbstractAdaptor
 
 from . import adaptors, db_utils, exceptions, utils
 
@@ -16,9 +16,7 @@ def apply_constraints(
     catalogue_sessionmaker = db_utils.get_catalogue_sessionmaker()
     with catalogue_sessionmaker() as catalogue_session:
         dataset = utils.lookup_resource_by_id(process_id, record, catalogue_session)
-    adaptor: AbstractAdaptor = adaptors.instantiate_adaptor(
-        dataset
-    )
+    adaptor: AbstractAdaptor = adaptors.instantiate_adaptor(dataset)
     try:
         constraints = adaptor.apply_constraints(request=request)
     except cads_adaptors.constraints.ParameterError as exc:


### PR DESCRIPTION
We were blocked from making the cads-adaptors more PEP8-ey due to this dependancy, and it is not necessary as the AbstractAdaptor is imported at the top level of cads-adaptors.