### PR TITLE
[WIP] add job statistics

### DIFF
--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -305,23 +305,16 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
                         job["process_id"], self.process_table, catalogue_session
                     )
                     results = utils.parse_results_from_broker_db(job, compute_session)
+                    statistics = utils.collect_job_statistics(job, compute_session)
                     jobs.append(
                         utils.make_status_info(
                             job=job,
                             results=results,
                             dataset_metadata=dataset_metadata,
+                            statistics=statistics,
                         )
                     )
-            statistics = {
-                "accepted_requests": cads_broker.database.count_requests(
-                    session=compute_session, status="accepted", user_uid=user_uid
-                ),
-                "running_requests": cads_broker.database.count_requests(
-                    session=compute_session, status="running", user_uid=user_uid
-                ),
-            }
         job_list = models.JobList(jobs=jobs)
-        job_list.statistics = statistics
         pagination_query_params = utils.make_pagination_query_params(
             jobs, sort_key=sortby.lstrip("-")
         )

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -343,7 +343,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
             raise ogc_api_processes_fastapi.exceptions.NoSuchJob()
         auth.verify_permission(user_uid, job)
         kwargs = {}
-        if origin == "portal":
+        if origin == "ui":
             kwargs["statistics"] = utils.collect_job_statistics(job, compute_session)
             kwargs["request"] = job["request_body"]["kwargs"]["request"]
         status_info = utils.make_status_info(job=job, **kwargs)

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -316,6 +316,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         auth_header: tuple[str, str] = fastapi.Depends(auth.get_auth_header),
         portal_header: str
         | None = fastapi.Header(None, alias=config.PORTAL_HEADER_NAME),
+        statistics: bool = fastapi.Query(False),
     ) -> models.StatusInfo:
         """Implement OGC API - Processes `GET /jobs/{job_id}` endpoint.
 
@@ -334,7 +335,6 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
             Job status information.
         """
         user_uid = auth.authenticate_user(auth_header, portal_header)
-        origin = auth.REQUEST_ORIGIN[auth_header[0]]
         portals = [p.strip() for p in portal_header.split(",")]
         compute_sessionmaker = db_utils.get_compute_sessionmaker()
         with compute_sessionmaker() as compute_session:
@@ -343,9 +343,9 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
             raise ogc_api_processes_fastapi.exceptions.NoSuchJob()
         auth.verify_permission(user_uid, job)
         kwargs = {}
-        if origin == "ui":
+        if statistics:
             kwargs["statistics"] = utils.collect_job_statistics(job, compute_session)
-            kwargs["request"] = job["request_body"]["kwargs"]["request"]
+        kwargs["request"] = job["request_body"]["kwargs"]["request"]
         status_info = utils.make_status_info(job=job, **kwargs)
         return status_info
 

--- a/cads_processing_api_service/models.py
+++ b/cads_processing_api_service/models.py
@@ -34,7 +34,7 @@ class StatusInfo(ogc_api_processes_fastapi.models.StatusInfo):
         str,
         ogc_api_processes_fastapi.models.InlineOrRefData
         | list[ogc_api_processes_fastapi.models.InlineOrRefData],
-    ]
+    ] | None = None
     results: dict[str, Any] | None = None
     processDescription: dict[str, Any] | None = None
     statistics: dict[str, Any] | None = None

--- a/cads_processing_api_service/models.py
+++ b/cads_processing_api_service/models.py
@@ -37,8 +37,8 @@ class StatusInfo(ogc_api_processes_fastapi.models.StatusInfo):
     ]
     results: dict[str, Any] | None = None
     processDescription: dict[str, Any] | None = None
+    statistics: dict[str, Any] | None = None
 
 
 class JobList(ogc_api_processes_fastapi.models.JobList):
     jobs: list[StatusInfo]  # type: ignore
-    statistics: dict[str, Any] | None = None

--- a/cads_processing_api_service/utils.py
+++ b/cads_processing_api_service/utils.py
@@ -441,10 +441,26 @@ def parse_results_from_broker_db(
     return results
 
 
+# Mocked function
+def collect_job_statistics(
+    job: dict[str, Any], session: sqlalchemy.orm.Session
+) -> dict[str, Any]:
+    statistics = {
+        "running_requests_per_user_and_adaptor": 1,
+        "queued_requests_per_user_and_adaptor": 10,
+        "running_requests_per_adaptor": 1,
+        "queued_requests_per_adaptor": 10,
+        "active_users_per_adaptor": 1,
+        "waiting_users_per_adaptor": 10,
+    }
+    return statistics
+
+
 def make_status_info(
     job: dict[str, Any],
     results: dict[str, Any] | None = None,
     dataset_metadata: cads_catalogue.database.Resource | None = None,
+    statistics: dict[str, Any] | None = None,
 ) -> models.StatusInfo:
     """Compose job's status information.
 
@@ -456,6 +472,8 @@ def make_status_info(
         Results description, by default None
     dataset_metadata : cads_catalogue.database.Resource | None, optional
         Dataset metadata, by default None
+    statistics : dict[str, Any] | None, optional
+        Job statistics, by default None
 
     Returns
     -------
@@ -480,4 +498,6 @@ def make_status_info(
         status_info.results = results
     if dataset_metadata:
         status_info.processDescription = {"title": dataset_metadata.title}
+    if statistics:
+        status_info.statistics = statistics
     return status_info

--- a/cads_processing_api_service/utils.py
+++ b/cads_processing_api_service/utils.py
@@ -458,6 +458,7 @@ def collect_job_statistics(
 
 def make_status_info(
     job: dict[str, Any],
+    request: dict[str, Any] | None = None,
     results: dict[str, Any] | None = None,
     dataset_metadata: cads_catalogue.database.Resource | None = None,
     statistics: dict[str, Any] | None = None,
@@ -480,20 +481,18 @@ def make_status_info(
     models.StatusInfo
         Job status information.
     """
-    request_uid = job["request_uid"]
-    process_id = job["process_id"]
-    job_status = job["status"]
     status_info = models.StatusInfo(
         type="process",
-        jobID=request_uid,
-        processID=process_id,
-        status=job_status,
+        jobID=job["request_uid"],
+        processID=job["process_id"],
+        status=job["status"],
         created=job["created_at"],
         started=job["started_at"],
         finished=job["finished_at"],
         updated=job["updated_at"],
-        request=job["request_body"]["kwargs"]["request"],
     )
+    if request:
+        status_info.request = request
     if results:
         status_info.results = results
     if dataset_metadata:

--- a/cads_processing_api_service/utils.py
+++ b/cads_processing_api_service/utils.py
@@ -446,12 +446,12 @@ def collect_job_statistics(
     job: dict[str, Any], session: sqlalchemy.orm.Session
 ) -> dict[str, Any]:
     statistics = {
-        "running_requests_per_user_and_adaptor": 1,
-        "queued_requests_per_user_and_adaptor": 10,
+        "running_requests_per_user_adaptor": 1,
+        "queued_requests_per_user_adaptor": 0,
         "running_requests_per_adaptor": 1,
-        "queued_requests_per_adaptor": 10,
+        "queued_requests_per_adaptor": 0,
         "active_users_per_adaptor": 1,
-        "waiting_users_per_adaptor": 10,
+        "waiting_users_per_adaptor": 0,
     }
     return statistics
 

--- a/tests/test_30_utils.py
+++ b/tests/test_30_utils.py
@@ -16,7 +16,6 @@ import unittest.mock
 from typing import Any
 
 import cads_broker
-import cads_catalogue.database
 import ogc_api_processes_fastapi.exceptions
 import ogc_api_processes_fastapi.models
 import pytest
@@ -270,8 +269,7 @@ def test_make_status_info() -> None:
         "updated_at": "2023-01-01T16:20:12.175021",
         "request_body": {"kwargs": {"request": {"product_type": ["reanalysis"]}}},
     }
-    datset_metadata = cads_catalogue.database.Resource(title="Dataset title")
-    status_info = utils.make_status_info(job, dataset_metadata=datset_metadata)
+    status_info = utils.make_status_info(job)
     exp_status_info = models.StatusInfo(
         type="process",
         jobID=job["request_uid"],
@@ -281,8 +279,6 @@ def test_make_status_info() -> None:
         started=job["started_at"],
         finished=job["finished_at"],
         updated=job["updated_at"],
-        request=job["request_body"]["kwargs"]["request"],
-        processDescription={"title": "Dataset title"},
     )
     assert status_info == exp_status_info
 


### PR DESCRIPTION
This PR add the possibility to receive (mock) queue statistics within the response of the GET /jobs/<job_id> endpoint. This information is added if the boolean query parameter `statistics` is set to `true`.