### PR TITLE
Add request labels

### DIFF
--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -317,6 +317,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         portal_header: str
         | None = fastapi.Header(None, alias=config.PORTAL_HEADER_NAME),
         statistics: bool = fastapi.Query(False),
+        request: bool = fastapi.Query(False),
     ) -> models.StatusInfo:
         """Implement OGC API - Processes `GET /jobs/{job_id}` endpoint.
 
@@ -343,21 +344,22 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
             raise ogc_api_processes_fastapi.exceptions.NoSuchJob()
         auth.verify_permission(user_uid, job)
         kwargs = {}
-        request_ids = job["request_body"]["kwargs"]["request"]
-        catalogue_sessionmaker = db_utils.get_catalogue_sessionmaker()
-        with catalogue_sessionmaker() as catalogue_session:
-            resource: cads_catalogue.Resource = utils.lookup_resource_by_id(
-                id=job["process_id"],
-                record=self.process_table,
-                session=catalogue_session,
-            )
-        input_form = resource.form_data
-        kwargs["request"] = {
-            "ids": request_ids,
-            "labels": translators.translate_request_ids_into_labels(
-                request_ids, input_form
-            ),
-        }
+        if request:
+            request_ids = job["request_body"]["kwargs"]["request"]
+            catalogue_sessionmaker = db_utils.get_catalogue_sessionmaker()
+            with catalogue_sessionmaker() as catalogue_session:
+                resource: cads_catalogue.Resource = utils.lookup_resource_by_id(
+                    id=job["process_id"],
+                    record=self.process_table,
+                    session=catalogue_session,
+                )
+            input_form = resource.form_data
+            kwargs["request"] = {
+                "ids": request_ids,
+                "labels": translators.translate_request_ids_into_labels(
+                    request_ids, input_form
+                ),
+            }
         if statistics:
             kwargs["statistics"] = utils.collect_job_statistics(job, compute_session)
         status_info = utils.make_status_info(job=job, **kwargs)

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -36,7 +36,7 @@ import sqlalchemy.orm.exc
 import sqlalchemy.sql.selectable
 import structlog
 
-from . import adaptors, auth, config, db_utils, models, serializers, utils
+from . import adaptors, auth, config, db_utils, models, serializers, translators, utils
 from .metrics import handle_download_metrics
 
 logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
@@ -343,9 +343,23 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
             raise ogc_api_processes_fastapi.exceptions.NoSuchJob()
         auth.verify_permission(user_uid, job)
         kwargs = {}
-        if origin == "ui":
+        if origin == "api":
             kwargs["statistics"] = utils.collect_job_statistics(job, compute_session)
-            kwargs["request"] = job["request_body"]["kwargs"]["request"]
+            request_ids = job["request_body"]["kwargs"]["request"]
+            catalogue_sessionmaker = db_utils.get_catalogue_sessionmaker()
+            with catalogue_sessionmaker() as catalogue_session:
+                resource: cads_catalogue.Resource = utils.lookup_resource_by_id(
+                    id=job["process_id"],
+                    record=self.process_table,
+                    session=catalogue_session,
+                )
+            input_form = resource.form_data
+            kwargs["request"] = {
+                "ids": request_ids,
+                "labels": translators.translate_request_ids_into_labels(
+                    request_ids, input_form
+                ),
+            }
         status_info = utils.make_status_info(job=job, **kwargs)
         return status_info
 

--- a/cads_processing_api_service/models.py
+++ b/cads_processing_api_service/models.py
@@ -25,16 +25,21 @@ class Licence(pydantic.BaseModel):
     revision: int
 
 
+class Request(pydantic.BaseModel):
+    ids: dict[
+        str,
+        ogc_api_processes_fastapi.models.InlineOrRefData
+        | list[ogc_api_processes_fastapi.models.InlineOrRefData],
+    ] | None = None
+    labels: dict[str, str | list[str]] | None = None
+
+
 class Execute(ogc_api_processes_fastapi.models.Execute):
     acceptedLicences: list[Licence] | None = None
 
 
 class StatusInfo(ogc_api_processes_fastapi.models.StatusInfo):
-    request: dict[
-        str,
-        ogc_api_processes_fastapi.models.InlineOrRefData
-        | list[ogc_api_processes_fastapi.models.InlineOrRefData],
-    ] | None = None
+    request: Request | None = None
     results: dict[str, Any] | None = None
     processDescription: dict[str, Any] | None = None
     statistics: dict[str, Any] | None = None

--- a/cads_processing_api_service/translators.py
+++ b/cads_processing_api_service/translators.py
@@ -127,3 +127,26 @@ def translate_cds_form(
             }
 
     return ogc_inputs
+
+
+def translate_request_ids_into_labels(
+    request: dict[str, Any], cds_form: list[Any] | dict[str, Any]
+) -> dict[str, Any]:
+    if not isinstance(cds_form, list):
+        cds_form = [
+            cds_form,
+        ]
+    request_labels = {}
+    for cds_input_schema in cds_form:
+        input_name = cds_input_schema["name"]
+        if input_name in request:
+            input_ids = request[input_name]
+            if not isinstance(input_ids, list):
+                input_ids = [
+                    input_ids,
+                ]
+            input_labels = extract_labels(cds_input_schema)
+            request_labels[cds_input_schema["label"]] = [
+                input_labels[input_id] for input_id in input_ids
+            ]
+    return request_labels

--- a/tests/test_10_translators.py
+++ b/tests/test_10_translators.py
@@ -16,17 +16,23 @@ import cads_processing_api_service.translators
 
 TEST_INPUT = {
     "string_list": {
-        "details": {"values": ["val1", "val2", "val3"]},
+        "details": {"labels": {"val1": "Val1", "val2": "Val2", "val3": "Val3"}},
         "type": "StringListWidget",
     },
     "string_list_array": {
         "details": {
-            "groups": [{"values": ["val1", "val2"]}, {"values": ["val2", "val3"]}]
+            "groups": [
+                {"labels": {"val1": "Val1", "val2": "Val2"}},
+                {"labels": {"val2": "Val2", "val3": "Val3"}},
+            ]
         },
         "type": "StringListArrayWidget",
     },
     "string_choice": {
-        "details": {"values": ["val1", "val2", "val3"], "default": "val1"},
+        "details": {
+            "labels": {"val1": "Val1", "val2": "Val2", "val3": "Val3"},
+            "default": "val1",
+        },
         "type": "StringChoiceWidget",
     },
     "geographic_extent_map": {
@@ -38,14 +44,14 @@ TEST_INPUT = {
             "groups": [
                 {
                     "groups": [
-                        {"values": ["val1", "val2"]},
-                        {"values": ["val2", "val3"]},
+                        {"labels": {"val1": "Val1", "val2": "Val2"}},
+                        {"labels": {"val2": "Val2", "val3": "Val3"}},
                     ]
                 },
                 {
                     "groups": [
-                        {"values": ["val4", "val5"]},
-                        {"values": ["val5", "val6"]},
+                        {"labels": {"val4": "Val4", "val5": "Val5"}},
+                        {"labels": {"val5": "Val5", "val6": "Val6"}},
                     ]
                 },
             ]

--- a/tests/test_30_utils.py
+++ b/tests/test_30_utils.py
@@ -281,11 +281,12 @@ def test_make_status_info() -> None:
         started=job["started_at"],
         finished=job["finished_at"],
         updated=job["updated_at"],
-        request=job["request_body"]["kwargs"]["request"],
         processDescription={"title": "Dataset title"},
     )
     assert status_info == exp_status_info
 
     exp_results = {"key": "value"}
-    status_info = utils.make_status_info(job, results=exp_results)
+    status_info = utils.make_status_info(
+        job, results=exp_results, request=job["request_body"]["kwargs"]["request"]
+    )
     assert status_info.results == exp_results


### PR DESCRIPTION
This PR enable showing of request ids and labels within the response to the GET /jobs/<job_id> endpoint. 
This additional information is added to the response if the request has the boolean query parameter `request` set to `true`, and is reported in the fields:
```
"request": {
   "ids": {...},
   "labels": {...}
}
```