### PR TITLE
Add request ids and labels to GET /jobs/<job_id>

### DIFF
--- a/cads_processing_api_service/adaptors.py
+++ b/cads_processing_api_service/adaptors.py
@@ -70,10 +70,12 @@ def make_system_job_kwargs(
     system_job_kwargs = {
         "entry_point": adaptor_properties["entry_point"],
         "setup_code": adaptor_properties["setup_code"],
-        "adaptor_config": adaptor_properties["config"],
-        "adaptor_form": adaptor_properties["form"],
         "resources": resources,
-        "request": request["inputs"],
+        "kwargs": {
+            "form": adaptor_properties["form"],
+            "config": adaptor_properties["config"],
+            "request": request["inputs"],
+        },
     }
     return system_job_kwargs
 

--- a/cads_processing_api_service/adaptors.py
+++ b/cads_processing_api_service/adaptors.py
@@ -71,11 +71,9 @@ def make_system_job_kwargs(
         "entry_point": adaptor_properties["entry_point"],
         "setup_code": adaptor_properties["setup_code"],
         "adaptor_config": adaptor_properties["config"],
+        "adaptor_form": adaptor_properties["form"],
         "resources": resources,
-        "kwargs": {
-            "form": adaptor_properties["form"],
-            "request": request["inputs"],
-        },
+        "request": request["inputs"],
     }
     return system_job_kwargs
 

--- a/cads_processing_api_service/adaptors.py
+++ b/cads_processing_api_service/adaptors.py
@@ -70,10 +70,10 @@ def make_system_job_kwargs(
     system_job_kwargs = {
         "entry_point": adaptor_properties["entry_point"],
         "setup_code": adaptor_properties["setup_code"],
+        "adaptor_config": adaptor_properties["config"],
         "resources": resources,
         "kwargs": {
             "form": adaptor_properties["form"],
-            "config": adaptor_properties["config"],
             "request": request["inputs"],
         },
     }

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -36,7 +36,7 @@ import sqlalchemy.orm.exc
 import sqlalchemy.sql.selectable
 import structlog
 
-from . import adaptors, auth, config, db_utils, models, serializers, utils
+from . import adaptors, auth, config, db_utils, models, serializers, translators, utils
 from .metrics import handle_download_metrics
 
 logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
@@ -317,6 +317,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         portal_header: str
         | None = fastapi.Header(None, alias=config.PORTAL_HEADER_NAME),
         statistics: bool = fastapi.Query(False),
+        request: bool = fastapi.Query(False),
     ) -> models.StatusInfo:
         """Implement OGC API - Processes `GET /jobs/{job_id}` endpoint.
 
@@ -343,6 +344,22 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
             raise ogc_api_processes_fastapi.exceptions.NoSuchJob()
         auth.verify_permission(user_uid, job)
         kwargs = {}
+        if request:
+            request_ids = job["request_body"]["kwargs"]["request"]
+            catalogue_sessionmaker = db_utils.get_catalogue_sessionmaker()
+            with catalogue_sessionmaker() as catalogue_session:
+                resource: cads_catalogue.Resource = utils.lookup_resource_by_id(
+                    id=job["process_id"],
+                    record=self.process_table,
+                    session=catalogue_session,
+                )
+            input_form = resource.form_data
+            kwargs["request"] = {
+                "ids": request_ids,
+                "labels": translators.translate_request_ids_into_labels(
+                    request_ids, input_form
+                ),
+            }
         if statistics:
             kwargs["statistics"] = utils.collect_job_statistics(job, compute_session)
         status_info = utils.make_status_info(job=job, **kwargs)

--- a/cads_processing_api_service/models.py
+++ b/cads_processing_api_service/models.py
@@ -25,11 +25,21 @@ class Licence(pydantic.BaseModel):
     revision: int
 
 
+class Request(pydantic.BaseModel):
+    ids: dict[
+        str,
+        ogc_api_processes_fastapi.models.InlineOrRefData
+        | list[ogc_api_processes_fastapi.models.InlineOrRefData],
+    ] | None = None
+    labels: dict[str, str | list[str]] | None = None
+
+
 class Execute(ogc_api_processes_fastapi.models.Execute):
     acceptedLicences: list[Licence] | None = None
 
 
 class StatusInfo(ogc_api_processes_fastapi.models.StatusInfo):
+    request: Request | None = None
     results: dict[str, Any] | None = None
     processDescription: dict[str, Any] | None = None
     statistics: dict[str, Any] | None = None

--- a/cads_processing_api_service/utils.py
+++ b/cads_processing_api_service/utils.py
@@ -458,6 +458,7 @@ def collect_job_statistics(
 
 def make_status_info(
     job: dict[str, Any],
+    request: dict[str, Any] | None = None,
     results: dict[str, Any] | None = None,
     dataset_metadata: cads_catalogue.database.Resource | None = None,
     statistics: dict[str, Any] | None = None,
@@ -489,8 +490,9 @@ def make_status_info(
         started=job["started_at"],
         finished=job["finished_at"],
         updated=job["updated_at"],
-        request=job["request_body"]["kwargs"]["request"],
     )
+    if request:
+        status_info.request = request
     if results:
         status_info.results = results
     if dataset_metadata:

--- a/tests/test_30_utils.py
+++ b/tests/test_30_utils.py
@@ -279,6 +279,5 @@ def test_make_status_info() -> None:
         started=job["started_at"],
         finished=job["finished_at"],
         updated=job["updated_at"],
-        request=job["request_body"]["request"],
     )
     assert status_info == exp_status_info


### PR DESCRIPTION
This PR enables showing of request ids and labels within the response to the GET /jobs/<job_id> endpoint.
This additional information is added to the response if the request has the boolean query parameter request set to true, and is reported in the fields:

```
"request": {
   "ids": {...},
   "labels": {...}
}
```