### PR TITLE
Add job's log to job status

### DIFF
--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -323,6 +323,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         | None = fastapi.Header(None, alias=config.PORTAL_HEADER_NAME),
         statistics: bool = fastapi.Query(False),
         request: bool = fastapi.Query(False),
+        log: bool = fastapi.Query(False),
     ) -> models.StatusInfo:
         """Implement OGC API - Processes `GET /jobs/{job_id}` endpoint.
 
@@ -334,6 +335,14 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
             Job identifer.
         auth_header : tuple[str, str], optional
             Authorization header
+        portal_header : str | None, optional
+            Portal header
+        statistics : bool, optional
+            Whether to include job statistics in the response
+        request : bool, optional
+            Whether to include the request in the response
+        log : bool, optional
+            Whether to include the job's log in the response
 
         Returns
         -------
@@ -367,6 +376,8 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
             }
         if statistics:
             kwargs["statistics"] = utils.collect_job_statistics(job, compute_session)
+        if log:
+            kwargs["log"] = utils.extract_job_log(job)
         status_info = utils.make_status_info(job=job, **kwargs)
         return status_info
 

--- a/cads_processing_api_service/models.py
+++ b/cads_processing_api_service/models.py
@@ -43,6 +43,7 @@ class StatusInfo(ogc_api_processes_fastapi.models.StatusInfo):
     results: dict[str, Any] | None = None
     processDescription: dict[str, Any] | None = None
     statistics: dict[str, Any] | None = None
+    log: list[str] | None = None
 
 
 class JobList(ogc_api_processes_fastapi.models.JobList):

--- a/cads_processing_api_service/utils.py
+++ b/cads_processing_api_service/utils.py
@@ -534,6 +534,6 @@ def make_status_info(
         status_info.processDescription = {"title": dataset_metadata.title}
     if statistics:
         status_info.statistics = statistics
-    if log:
+    if log is not None:
         status_info.log = log
     return status_info


### PR DESCRIPTION
In this PR, a new query parameter (`log: bool, default is False`) is added to the the `GET /jobs/<job-id>` endpoint: if `True`, the log of the job (the content of the `response_user_visible_log` field in the `borker-db`) is added to the endpoint response.
More specifically, if `log==True` the response will be something like this:
```
{
    "processID": "reanalysis-era5-pressure-levels",
    "type": "process",
    "jobID": "2a729aff-90c6-45a8-9949-e16981c5c554",
    "status": "running",
    "created": "2023-09-27T08:41:57.700218",
    "started": "2023-09-27T08:41:58.177677",
    "updated": "2023-09-27T08:41:58.177677",
    "links": [
        {
            "href": "http://localhost:8080/api/retrieve/v1/jobs/2a729aff-90c6-45a8-9949-e16981c5c554",
            "rel": "self",
            "type": "application/json"
        }
    ],
    "log": [
        <log_message_1>,
        <log_message_2>,
    ]
}
```