### PR TITLE
Use read/write connection modes to the compute-db

### DIFF
--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -355,11 +355,22 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         """
         user_uid = auth.authenticate_user(auth_header, portal_header)
         portals = [p.strip() for p in portal_header.split(",")]
-        compute_sessionmaker = db_utils.get_compute_sessionmaker(
-            mode=db_utils.ConnectionMode.read
-        )
-        with compute_sessionmaker() as compute_session:
-            job = utils.get_job_from_broker_db(job_id=job_id, session=compute_session)
+        try:
+            compute_sessionmaker = db_utils.get_compute_sessionmaker(
+                mode=db_utils.ConnectionMode.read
+            )
+            with compute_sessionmaker() as compute_session:
+                job = utils.get_job_from_broker_db(
+                    job_id=job_id, session=compute_session
+                )
+        except ogc_api_processes_fastapi.exceptions.NoSuchJob:
+            compute_sessionmaker = db_utils.get_compute_sessionmaker(
+                mode=db_utils.ConnectionMode.write
+            )
+            with compute_sessionmaker() as compute_session:
+                job = utils.get_job_from_broker_db(
+                    job_id=job_id, session=compute_session
+                )
         if job["portal"] not in portals:
             raise ogc_api_processes_fastapi.exceptions.NoSuchJob()
         auth.verify_permission(user_uid, job)
@@ -413,14 +424,31 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         structlog.contextvars.bind_contextvars(job_id=job_id)
         user_uid = auth.authenticate_user(auth_header, portal_header)
         structlog.contextvars.bind_contextvars(user_id=user_uid)
-        compute_sessionmaker = db_utils.get_compute_sessionmaker(
-            mode=db_utils.ConnectionMode.read
-        )
-        with compute_sessionmaker() as compute_session:
-            job = utils.get_job_from_broker_db(job_id=job_id, session=compute_session)
-            auth.verify_permission(user_uid, job)
-            results = utils.get_results_from_broker_db(job=job, session=compute_session)
-            handle_download_metrics(job, results)
+        try:
+            compute_sessionmaker = db_utils.get_compute_sessionmaker(
+                mode=db_utils.ConnectionMode.read
+            )
+            with compute_sessionmaker() as compute_session:
+                job = utils.get_job_from_broker_db(
+                    job_id=job_id, session=compute_session
+                )
+                auth.verify_permission(user_uid, job)
+                results = utils.get_results_from_broker_db(
+                    job=job, session=compute_session
+                )
+        except ogc_api_processes_fastapi.exceptions.NoSuchJob:
+            compute_sessionmaker = db_utils.get_compute_sessionmaker(
+                mode=db_utils.ConnectionMode.write
+            )
+            with compute_sessionmaker() as compute_session:
+                job = utils.get_job_from_broker_db(
+                    job_id=job_id, session=compute_session
+                )
+                auth.verify_permission(user_uid, job)
+                results = utils.get_results_from_broker_db(
+                    job=job, session=compute_session
+                )
+        handle_download_metrics(job, results)
         return results
 
     def delete_job(

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -436,7 +436,10 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
                 results = utils.get_results_from_broker_db(
                     job=job, session=compute_session
                 )
-        except ogc_api_processes_fastapi.exceptions.NoSuchJob:
+        except (
+            ogc_api_processes_fastapi.exceptions.NoSuchJob,
+            ogc_api_processes_fastapi.exceptions.ResultsNotReady,
+        ):
             compute_sessionmaker = db_utils.get_compute_sessionmaker(
                 mode=db_utils.ConnectionMode.write
             )

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -202,7 +202,9 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         job_kwargs = adaptors.make_system_job_kwargs(
             resource, execution_content, adaptor.resources
         )
-        compute_sessionmaker = db_utils.get_compute_sessionmaker()
+        compute_sessionmaker = db_utils.get_compute_sessionmaker(
+            mode=db_utils.ConnectionMode.write
+        )
         with compute_sessionmaker() as compute_session:
             job = cads_broker.database.create_request(
                 session=compute_session,
@@ -284,7 +286,9 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
             statement, self.job_table, back, sort_key, sort_dir
         )
         statement = utils.apply_limit(statement, limit)
-        compute_sessionmaker = db_utils.get_compute_sessionmaker()
+        compute_sessionmaker = db_utils.get_compute_sessionmaker(
+            mode=db_utils.ConnectionMode.read
+        )
         catalogue_sessionmaker = db_utils.get_catalogue_sessionmaker()
         with compute_sessionmaker() as compute_session:
             job_entries = compute_session.scalars(statement).all()
@@ -351,7 +355,9 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         """
         user_uid = auth.authenticate_user(auth_header, portal_header)
         portals = [p.strip() for p in portal_header.split(",")]
-        compute_sessionmaker = db_utils.get_compute_sessionmaker()
+        compute_sessionmaker = db_utils.get_compute_sessionmaker(
+            mode=db_utils.ConnectionMode.read
+        )
         with compute_sessionmaker() as compute_session:
             job = utils.get_job_from_broker_db(job_id=job_id, session=compute_session)
         if job["portal"] not in portals:
@@ -407,7 +413,9 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         structlog.contextvars.bind_contextvars(job_id=job_id)
         user_uid = auth.authenticate_user(auth_header, portal_header)
         structlog.contextvars.bind_contextvars(user_id=user_uid)
-        compute_sessionmaker = db_utils.get_compute_sessionmaker()
+        compute_sessionmaker = db_utils.get_compute_sessionmaker(
+            mode=db_utils.ConnectionMode.read
+        )
         with compute_sessionmaker() as compute_session:
             job = utils.get_job_from_broker_db(job_id=job_id, session=compute_session)
             auth.verify_permission(user_uid, job)
@@ -441,7 +449,9 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         structlog.contextvars.bind_contextvars(job_id=job_id)
         user_uid = auth.authenticate_user(auth_header, portal_header)
         structlog.contextvars.bind_contextvars(user_id=user_uid)
-        compute_sessionmaker = db_utils.get_compute_sessionmaker()
+        compute_sessionmaker = db_utils.get_compute_sessionmaker(
+            mode=db_utils.ConnectionMode.write
+        )
         with compute_sessionmaker() as compute_session:
             job = utils.get_job_from_broker_db(job_id=job_id, session=compute_session)
             auth.verify_permission(user_uid, job)

--- a/cads_processing_api_service/db_utils.py
+++ b/cads_processing_api_service/db_utils.py
@@ -16,7 +16,6 @@
 
 import enum
 import functools
-from typing import Type
 
 import cads_broker.config
 import cads_catalogue.config
@@ -33,7 +32,7 @@ class ConnectionMode(str, enum.Enum):
 
 @functools.lru_cache()
 def get_compute_sessionmaker(
-    mode: Type[ConnectionMode] = ConnectionMode.write,
+    mode: ConnectionMode = ConnectionMode.write,
 ) -> sqlalchemy.orm.sessionmaker[sqlalchemy.orm.Session]:
     """Get an sqlalchemy.orm.sessionmaker object bound to the Broker database.
 

--- a/cads_processing_api_service/db_utils.py
+++ b/cads_processing_api_service/db_utils.py
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
+import enum
 import functools
+from typing import Type
 
 import cads_broker.config
 import cads_catalogue.config
@@ -22,9 +24,24 @@ import sqlalchemy
 import sqlalchemy.orm
 
 
+class ConnectionMode(str, enum.Enum):
+    """Database connection mode."""
+
+    read = "read"
+    write = "write"
+
+
 @functools.lru_cache()
-def get_compute_sessionmaker() -> sqlalchemy.orm.sessionmaker[sqlalchemy.orm.Session]:
+def get_compute_sessionmaker(
+    mode: Type[ConnectionMode] = ConnectionMode.write,
+) -> sqlalchemy.orm.sessionmaker[sqlalchemy.orm.Session]:
     """Get an sqlalchemy.orm.sessionmaker object bound to the Broker database.
+
+    Parameters
+    ----------
+    mode: ConnectionMode
+        Connection mode to the database. If ConnectionMode.read, the sessionmaker
+        will open a connection to a read-only hostname.
 
     Returns
     -------
@@ -32,8 +49,14 @@ def get_compute_sessionmaker() -> sqlalchemy.orm.sessionmaker[sqlalchemy.orm.Ses
         sqlalchemy.orm.sessionmaker object bound to the Broker database.
     """
     broker_settings = cads_broker.config.ensure_settings()
+    if mode == ConnectionMode.write:
+        connection_string = broker_settings.connection_string
+    elif mode == ConnectionMode.read:
+        connection_string = broker_settings.connection_string_read
+    else:
+        raise ValueError(f"Invalid connection mode: {str(mode)}")
     broker_engine = sqlalchemy.create_engine(
-        broker_settings.connection_string,
+        connection_string,
         pool_timeout=broker_settings.pool_timeout,
         pool_recycle=broker_settings.pool_recycle,
     )


### PR DESCRIPTION
This PR implements:
- usage of two different connection modes (read and write) to the compute-db;
- retry on write compute-db hostname if `NoSuchJob` is returned by `get_job_from_broker_db`


**Requires**:
- https://github.com/ecmwf-projects/cads-broker/tree/implement-read-and-write