### PR TITLE
Get qos status information from GET /jobs/<job_id>

### DIFF
--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -392,7 +392,10 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
                 ),
             }
         if statistics:
-            kwargs["statistics"] = utils.collect_job_statistics(job, compute_session)
+            kwargs["statistics"] = {
+                **utils.collect_job_statistics(job, compute_session),
+                "qos_status": cads_broker.database.get_qos_status_from_request(job),
+            }
         if log:
             kwargs["log"] = utils.extract_job_log(job)
         status_info = utils.make_status_info(job=job, **kwargs)


### PR DESCRIPTION
This PR adds a field `qos_status` to the response of the `GET /jobs/<job_id>?statistics=True`, containing information on the QoS rules preventing the job to go from the `accepted` to the `running` status.
The field is shown in the endpoint response as follows:
```
{
    "processID": "reanalysis-era5-pressure-levels",
    "type": "process",
    "jobID": "c7ac969c-a683-4461-af76-dae938da444f",
    ...
    "statistics": {
        ...
        "qos_status": {
            "user": [
                "user_related_limit_1",
                "user_related_limit_2"
            ],
            "limit": [
                "general_limit_1",
                "general_limit_2
            ]
        }
    }
}