### PR TITLE
Refactor client

### DIFF
--- a/cads_processing_api_service/auth.py
+++ b/cads_processing_api_service/auth.py
@@ -18,6 +18,7 @@ import urllib.parse
 from typing import Any
 
 import cachetools
+import cads_broker
 import fastapi
 import requests
 
@@ -127,7 +128,7 @@ def authenticate_user(
     return user_uid
 
 
-def verify_permission(user_uid: str, job: dict[str, Any]) -> None:
+def verify_permission(user_uid: str, job: cads_broker.SystemRequest) -> None:
     """Verify if a user has permission to interact with a job.
 
     Parameters
@@ -142,7 +143,7 @@ def verify_permission(user_uid: str, job: dict[str, Any]) -> None:
     exceptions.PermissionDenied
         Raised if the user has no permission to interact with the job.
     """
-    if job["user_uid"] != user_uid:
+    if job.user_uid != user_uid:
         raise exceptions.PermissionDenied()
 
 

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -141,7 +141,9 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         )
         with catalogue_sessionmaker() as catalogue_session:
             resource = utils.lookup_resource_by_id(
-                id=process_id, record=self.process_table, session=catalogue_session
+                resource_id=process_id,
+                table=self.process_table,
+                session=catalogue_session,
             )
         process_description = serializers.serialize_process_description(resource)
         process_description.outputs = {
@@ -198,7 +200,9 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         )
         with catalogue_sessionmaker() as catalogue_session:
             resource: cads_catalogue.database.Resource = utils.lookup_resource_by_id(
-                id=process_id, record=self.process_table, session=catalogue_session
+                resource_id=process_id,
+                table=self.process_table,
+                session=catalogue_session,
             )
         adaptor = adaptors.instantiate_adaptor(resource)
         licences = adaptor.get_licences(execution_content)

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -439,7 +439,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
                     job_id=job_id, session=compute_session
                 )
             auth.verify_permission(user_uid, job)
-            results = utils.get_results_from_broker_db(job=job)
+            results = utils.get_results_from_job(job=job)
         except (
             ogc_api_processes_fastapi.exceptions.NoSuchJob,
             ogc_api_processes_fastapi.exceptions.ResultsNotReady,
@@ -452,7 +452,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
                     job_id=job_id, session=compute_session
                 )
             auth.verify_permission(user_uid, job)
-            results = utils.get_results_from_broker_db(job=job)
+            results = utils.get_results_from_job(job=job)
         handle_download_metrics(job, results)
         return results
 

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -305,15 +305,18 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         )
         for job in job_entries:
             with catalogue_sessionmaker() as catalogue_session:
-                dataset_metadata = utils.lookup_resource_by_id(
-                    job.process_id, self.process_table, catalogue_session
+                (dataset_title,) = utils.get_resource_properties(
+                    resource_id=job.process_id,
+                    properties="title",
+                    table=self.process_table,
+                    session=catalogue_session,
                 )
             results = utils.parse_results_from_broker_db(job)
             jobs.append(
                 utils.make_status_info(
                     job=job,
                     results=results,
-                    dataset_metadata=dataset_metadata,
+                    dataset_metadata={"title": dataset_title},
                 )
             )
         job_list = models.JobList(
@@ -392,16 +395,16 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
                 db_utils.ConnectionMode.read
             )
             with catalogue_sessionmaker() as catalogue_session:
-                resource: cads_catalogue.Resource = utils.lookup_resource_by_id(
-                    id=job.process_id,
-                    record=self.process_table,
+                (form_data,) = utils.get_resource_properties(
+                    resource_id=job.process_id,
+                    properties="form_data",
+                    table=self.process_table,
                     session=catalogue_session,
                 )
-            input_form = resource.form_data
             kwargs["request"] = {
                 "ids": request_ids,
                 "labels": translators.translate_request_ids_into_labels(
-                    request_ids, input_form
+                    request_ids, form_data
                 ),
             }
         if statistics:

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -379,7 +379,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         auth.verify_permission(user_uid, job)
         kwargs = {}
         if request:
-            request_ids = job.request_body.request
+            request_ids = job.request_body["request"]
             catalogue_sessionmaker = db_utils.get_catalogue_sessionmaker()
             with catalogue_sessionmaker() as catalogue_session:
                 resource: cads_catalogue.Resource = utils.lookup_resource_by_id(

--- a/cads_processing_api_service/constraints.py
+++ b/cads_processing_api_service/constraints.py
@@ -12,12 +12,14 @@ def apply_constraints(
     process_id: str = fastapi.Path(...),
     request: dict[str, Any] = fastapi.Body(...),
 ) -> dict[str, Any]:
-    record = cads_catalogue.database.Resource
+    table = cads_catalogue.database.Resource
     catalogue_sessionmaker = db_utils.get_catalogue_sessionmaker(
         db_utils.ConnectionMode.read
     )
     with catalogue_sessionmaker() as catalogue_session:
-        dataset = utils.lookup_resource_by_id(process_id, record, catalogue_session)
+        dataset = utils.lookup_resource_by_id(
+            resource_id=process_id, table=table, session=catalogue_session
+        )
     adaptor: cads_adaptors.AbstractAdaptor = adaptors.instantiate_adaptor(dataset)
     try:
         constraints: dict[str, Any] = adaptor.apply_constraints(request=request)

--- a/cads_processing_api_service/utils.py
+++ b/cads_processing_api_service/utils.py
@@ -388,8 +388,8 @@ def get_job_from_broker_db(
     return job
 
 
-def get_results_from_broker_db(job: cads_broker.SystemRequest) -> dict[str, Any]:
-    """Get job results description from the Broker database.
+def get_results_from_job(job: cads_broker.SystemRequest) -> dict[str, Any]:
+    """Get job results description from SystemRequest instance.
 
     Parameters
     ----------
@@ -419,7 +419,7 @@ def get_results_from_broker_db(job: cads_broker.SystemRequest) -> dict[str, Any]
     elif job_status == "failed":
         raise ogc_api_processes_fastapi.exceptions.JobResultsFailed(
             status_code=fastapi.status.HTTP_400_BAD_REQUEST,
-            traceback=job.response_error.message,
+            traceback=job.response_error["message"],
         )
     elif job_status in ("accepted", "running"):
         raise ogc_api_processes_fastapi.exceptions.ResultsNotReady(
@@ -430,7 +430,7 @@ def get_results_from_broker_db(job: cads_broker.SystemRequest) -> dict[str, Any]
 
 def parse_results_from_broker_db(job: cads_broker.SystemRequest) -> dict[str, Any]:
     try:
-        results = get_results_from_broker_db(job=job)
+        results = get_results_from_job(job=job)
     except ogc_api_processes_fastapi.exceptions.OGCAPIException as exc:
         results = exceptions.format_exception_content(exc=exc)
     return results

--- a/cads_processing_api_service/utils.py
+++ b/cads_processing_api_service/utils.py
@@ -419,7 +419,7 @@ def get_results_from_job(job: cads_broker.SystemRequest) -> dict[str, Any]:
     elif job_status == "failed":
         raise ogc_api_processes_fastapi.exceptions.JobResultsFailed(
             status_code=fastapi.status.HTTP_400_BAD_REQUEST,
-            traceback=job.response_error["message"],
+            traceback=str(job.response_error["message"]),
         )
     elif job_status in ("accepted", "running"):
         raise ogc_api_processes_fastapi.exceptions.ResultsNotReady(
@@ -439,8 +439,8 @@ def parse_results_from_broker_db(job: cads_broker.SystemRequest) -> dict[str, An
 def collect_job_statistics(
     job: cads_broker.SystemRequest, session: sqlalchemy.orm.Session
 ) -> dict[str, Any]:
-    entry_point = job.entry_point
-    user_uid = job.user_uid
+    entry_point = str(job.entry_point)
+    user_uid = str(job.user_uid)
     statistics = {
         "adaptor_entry_point": entry_point,
         "running_requests_per_user_adaptor": cads_broker.database.count_requests(
@@ -482,7 +482,7 @@ def collect_job_statistics(
 def extract_job_log(job: cads_broker.SystemRequest) -> list[str]:
     log = []
     if job.response_user_visible_log:
-        job_log = json.loads(job.response_user_visible_log)
+        job_log = json.loads(str(job.response_user_visible_log))
         for log_timestamp, log_message in job_log:
             log.append(log_message)
     return log

--- a/cads_processing_api_service/utils.py
+++ b/cads_processing_api_service/utils.py
@@ -54,20 +54,20 @@ class JobSortCriterion(str, enum.Enum):
         maxsize=config.ensure_settings().cache_resources_maxsize,
         ttl=config.ensure_settings().cache_resources_ttl,
     ),
-    key=lambda id, record, session: cachetools.keys.hashkey(id, record),
+    key=lambda resource_id, table, session: cachetools.keys.hashkey(resource_id, table),
 )
 def lookup_resource_by_id(
-    id: str,
-    record: type[cads_catalogue.database.Resource],
+    resource_id: str,
+    table: type[cads_catalogue.database.Resource],
     session: sqlalchemy.orm.Session,
 ) -> cads_catalogue.database.Resource:
     """Look for the resource identified by `id` into the Catalogue database.
 
     Parameters
     ----------
-    id : str
+    resource_id : str
         Resource identifier.
-    record : type[cads_catalogue.database.Resource]
+    table : type[cads_catalogue.database.Resource]
         Catalogue database table.
     session : sqlalchemy.orm.Session
         Catalogue database session.
@@ -83,9 +83,9 @@ def lookup_resource_by_id(
         Raised if no resource corresponding to the provided `id` is found.
     """
     statement = (
-        sa.select(record)
-        .options(sqlalchemy.orm.joinedload(record.licences))
-        .filter(record.resource_uid == id)
+        sa.select(table)
+        .options(sqlalchemy.orm.joinedload(table.licences))
+        .filter(table.resource_uid == resource_id)
     )
     try:
         row: cads_catalogue.database.Resource = (

--- a/tests/test_30_auth.py
+++ b/tests/test_30_auth.py
@@ -48,7 +48,7 @@ def test_check_licences() -> None:
 
 
 def test_verify_permission() -> None:
-    job = cads_broker.SystemRequest(user_uid="abc123")
+    job = cads_broker.SystemRequest(**{"user_uid": "abc123"})
     user_uid = "abc123"
     try:
         auth.verify_permission(user_uid, job)

--- a/tests/test_30_auth.py
+++ b/tests/test_30_auth.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import cads_broker
 import pytest
 
 from cads_processing_api_service import auth, exceptions
@@ -47,7 +48,7 @@ def test_check_licences() -> None:
 
 
 def test_verify_permission() -> None:
-    job = {"user_uid": "abc123"}
+    job = cads_broker.SystemRequest(user_uid="abc123")
     user_uid = "abc123"
     try:
         auth.verify_permission(user_uid, job)

--- a/tests/test_30_utils.py
+++ b/tests/test_30_utils.py
@@ -242,33 +242,33 @@ def test_get_job_from_broker_db() -> None:
 
 def test_get_results_from_job() -> None:
     job = cads_broker.SystemRequest(
-        status="successful",
-        request_uid="1234",
-        cache_entry=cacholote.database.CacheEntry(result={"args": [{"key": "value"}]}),
+        **{
+            "status": "successful",
+            "request_uid": "1234",
+            "cache_entry": cacholote.database.CacheEntry(
+                result={"args": [{"key": "value"}]}
+            ),
+        }
     )
     results = utils.get_results_from_job(job)
     exp_results = {"asset": {"value": {"key": "value"}}}
     assert results == exp_results
 
     job = cads_broker.SystemRequest(
-        status="failed",
-        request_uid="1234",
-        response_error={"message": "traceback"},
+        **{
+            "status": "failed",
+            "request_uid": "1234",
+            "response_error": {"message": "traceback"},
+        }
     )
     with pytest.raises(ogc_api_processes_fastapi.exceptions.JobResultsFailed):
         results = utils.get_results_from_job(job)
 
-    job = cads_broker.SystemRequest(
-        status="accepted",
-        request_uid="1234",
-    )
+    job = cads_broker.SystemRequest(**{"status": "accepted", "request_uid": "1234"})
     with pytest.raises(ogc_api_processes_fastapi.exceptions.ResultsNotReady):
         results = utils.get_results_from_job(job)
 
-    job = cads_broker.SystemRequest(
-        status="running",
-        request_uid="1234",
-    )
+    job = cads_broker.SystemRequest(**{"status": "running", "request_uid": "1234"})
     with pytest.raises(ogc_api_processes_fastapi.exceptions.ResultsNotReady):
         results = utils.get_results_from_job(job)
 


### PR DESCRIPTION
This PR:
- implements direct usage of the `cads_broker.SystemRequest` object instance wherever possible, instead of always converting it into a dictionary;
- rationalize sessions usage, especially in the `get_jobs` endpoint;
- rationalize results extraction from the `job` object in the `get_job_results` endpoint: previously, two queries to the broker-db where performed, now only one (this was the original motivation for this PR)

Blocked by:
- https://github.com/ecmwf-projects/cads-broker/pull/85