### PR TITLE
Fix handle_download_metrics

### DIFF
--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -470,7 +470,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
                 )
             auth.verify_permission(user_uid, job)
             results = utils.get_results_from_job(job=job)
-        handle_download_metrics(job, results)
+        handle_download_metrics(job.process_id, results)
         return results
 
     def delete_job(

--- a/cads_processing_api_service/metrics.py
+++ b/cads_processing_api_service/metrics.py
@@ -36,10 +36,9 @@ def handle_metrics(
     return starlette_exporter.handle_metrics(request)
 
 
-def handle_download_metrics(job: dict[str, Any], results: dict[str, Any]) -> None:
+def handle_download_metrics(dataset_id: str, results: dict[str, Any]) -> None:
     """Update the download metrics when a user downloads a dataset."""
     try:
-        dataset_id = job["process_id"]
         result_size = int(results["asset"]["value"]["file:size"])
         DOWNLOAD_BYTES.labels(dataset_id).observe(result_size)
     except Exception as e:

--- a/tests/test_40_metrics.py
+++ b/tests/test_40_metrics.py
@@ -18,19 +18,19 @@ from cads_processing_api_service import metrics
 
 
 def test_handle_download_metrics() -> None:
-    test_job = {"process_id": "test_process_id"}
+    test_dataset_id = "test_dataset_id"
     test_results = {"asset": {"value": {"file:size": 100}}}
     for _ in range(2):
-        metrics.handle_download_metrics(test_job, test_results)
+        metrics.handle_download_metrics(test_dataset_id, test_results)
 
     exp_download_bytes_count = 2
     res_download_bytes_count = prometheus_client.REGISTRY.get_sample_value(
-        "download_bytes_count", labels={"dataset_id": "test_process_id"}
+        "download_bytes_count", labels={"dataset_id": "test_dataset_id"}
     )
     assert res_download_bytes_count == exp_download_bytes_count
 
     exp_download_bytes_sum = 200
     res_download_bytes_sum = prometheus_client.REGISTRY.get_sample_value(
-        "download_bytes_sum", labels={"dataset_id": "test_process_id"}
+        "download_bytes_sum", labels={"dataset_id": "test_dataset_id"}
     )
     assert res_download_bytes_sum == exp_download_bytes_sum


### PR DESCRIPTION
This PR fix the `handle_download_metrics` function, changing it accordingly to changes in https://github.com/ecmwf-projects/cads-processing-api-service/pull/156