### PR TITLE
Make broker-db connection's pool parameters configurable

### DIFF
--- a/cads_processing_api_service/db_utils.py
+++ b/cads_processing_api_service/db_utils.py
@@ -58,6 +58,8 @@ def get_compute_sessionmaker(
         connection_string,
         pool_timeout=broker_settings.pool_timeout,
         pool_recycle=broker_settings.pool_recycle,
+        pool_size=broker_settings.pool_size,
+        max_overflow=broker_settings.max_overflow,
     )
     return sqlalchemy.orm.sessionmaker(broker_engine)
 


### PR DESCRIPTION
This PR:
- sets `pool_size` and `max_overflow` parameters when instantiating broker-db connection's engine, taking them from `cads_broker` settings (which makes them configurable via environment variables)

Blocked by:
- https://github.com/ecmwf-projects/cads-broker/pull/88