### PR TITLE
Add placeholder title for missing dataset in GET /jobs response

### DIFF
--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -306,12 +306,15 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         )
         for job in job_entries:
             with catalogue_sessionmaker() as catalogue_session:
-                (dataset_title,) = utils.get_resource_properties(
-                    resource_id=job.process_id,
-                    properties="title",
-                    table=self.process_table,
-                    session=catalogue_session,
-                )
+                try:
+                    (dataset_title,) = utils.get_resource_properties(
+                        resource_id=job.process_id,
+                        properties="title",
+                        table=self.process_table,
+                        session=catalogue_session,
+                    )
+                except ogc_api_processes_fastapi.exceptions.NoSuchProcess:
+                    dataset_title = config.ensure_settings().missing_dataset_title
             results = utils.parse_results_from_broker_db(job)
             jobs.append(
                 utils.make_status_info(

--- a/cads_processing_api_service/config.py
+++ b/cads_processing_api_service/config.py
@@ -45,6 +45,7 @@ class Settings(pydantic_settings.BaseSettings):
         "client = cads_api_client.ApiClient()\n"
         "client.retrieve(collection_id, **request)\n"
     )
+    missing_dataset_title: str = "Dataset not available"
 
     @property
     def profiles_api_url(self) -> str:


### PR DESCRIPTION
This PR adds a configurable placeholder text as dataset's title in the `GET /jobs` response when a particular dataset is no more present on the catalogue db