### PR TITLE
Add total jobs count to jobs list

### DIFF
--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -297,6 +297,10 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
             mode=db_utils.ConnectionMode.read
         )
         with compute_sessionmaker() as compute_session:
+            cads_broker.database.count_requests(
+                session=compute_session,
+                **job_filters,
+            )
             job_entries = compute_session.scalars(statement).all()
         if back:
             job_entries = reversed(job_entries)

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -334,7 +334,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         job_list = models.JobList(
             jobs=jobs,
             links=[ogc_api_processes_fastapi.models.Link(href="")],
-            additionalInfo={"totalCount": jobs_count},
+            additionalInfo=models.JobListAdditionalInfo(totalCount=jobs_count),
         )
         pagination_query_params = utils.make_pagination_query_params(
             jobs, sort_key=sortby.lstrip("-")

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -61,8 +61,9 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
     def get_processes(
         self,
         limit: int | None = fastapi.Query(10, ge=1, le=10000),
-        sortby: utils.ProcessSortCriterion
-        | None = fastapi.Query(utils.ProcessSortCriterion.resource_uid_asc),
+        sortby: utils.ProcessSortCriterion | None = fastapi.Query(
+            utils.ProcessSortCriterion.resource_uid_asc
+        ),
         cursor: str | None = fastapi.Query(None, include_in_schema=False),
         back: bool | None = fastapi.Query(None, include_in_schema=False),
     ) -> ogc_api_processes_fastapi.models.ProcessList:
@@ -167,8 +168,9 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         process_id: str = fastapi.Path(...),
         execution_content: models.Execute = fastapi.Body(...),
         auth_header: tuple[str, str] = fastapi.Depends(auth.get_auth_header),
-        portal_header: str
-        | None = fastapi.Header(None, alias=config.PORTAL_HEADER_NAME),
+        portal_header: str | None = fastapi.Header(
+            None, alias=config.PORTAL_HEADER_NAME
+        ),
     ) -> models.StatusInfo:
         """Implement OGC API - Processes `POST /processes/{process_id}/execution` endpoint.
 
@@ -232,13 +234,15 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         status: list[ogc_api_processes_fastapi.models.StatusCode]
         | None = fastapi.Query(None),
         limit: int | None = fastapi.Query(10, ge=1, le=10000),
-        sortby: utils.JobSortCriterion
-        | None = fastapi.Query(utils.JobSortCriterion.created_at_desc),
+        sortby: utils.JobSortCriterion | None = fastapi.Query(
+            utils.JobSortCriterion.created_at_desc
+        ),
         cursor: str | None = fastapi.Query(None, include_in_schema=False),
         back: bool | None = fastapi.Query(None, include_in_schema=False),
         auth_header: tuple[str, str] = fastapi.Depends(auth.get_auth_header),
-        portal_header: str
-        | None = fastapi.Header(None, alias=config.PORTAL_HEADER_NAME),
+        portal_header: str | None = fastapi.Header(
+            None, alias=config.PORTAL_HEADER_NAME
+        ),
     ) -> models.JobList:
         """Implement OGC API - Processes `GET /jobs` endpoint.
 
@@ -297,7 +301,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
             mode=db_utils.ConnectionMode.read
         )
         with compute_sessionmaker() as compute_session:
-            cads_broker.database.count_requests(
+            jobs_count = cads_broker.database.count_requests(
                 session=compute_session,
                 **job_filters,
             )
@@ -328,7 +332,9 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
                 )
             )
         job_list = models.JobList(
-            jobs=jobs, links=[ogc_api_processes_fastapi.models.Link(href="")]
+            jobs=jobs,
+            links=[ogc_api_processes_fastapi.models.Link(href="")],
+            additionalInfo={"totalCount": jobs_count},
         )
         pagination_query_params = utils.make_pagination_query_params(
             jobs, sort_key=sortby.lstrip("-")
@@ -341,8 +347,9 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         self,
         job_id: str = fastapi.Path(...),
         auth_header: tuple[str, str] = fastapi.Depends(auth.get_auth_header),
-        portal_header: str
-        | None = fastapi.Header(None, alias=config.PORTAL_HEADER_NAME),
+        portal_header: str | None = fastapi.Header(
+            None, alias=config.PORTAL_HEADER_NAME
+        ),
         statistics: bool = fastapi.Query(False),
         request: bool = fastapi.Query(False),
         log: bool = fastapi.Query(False),
@@ -429,8 +436,9 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         self,
         job_id: str = fastapi.Path(...),
         auth_header: tuple[str, str] = fastapi.Depends(auth.get_auth_header),
-        portal_header: str
-        | None = fastapi.Header(None, alias=config.PORTAL_HEADER_NAME),
+        portal_header: str | None = fastapi.Header(
+            None, alias=config.PORTAL_HEADER_NAME
+        ),
     ) -> ogc_api_processes_fastapi.models.Results:
         """Implement OGC API - Processes `GET /jobs/{job_id}/results` endpoint.
 
@@ -481,8 +489,9 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         self,
         job_id: str = fastapi.Path(...),
         auth_header: tuple[str, str] = fastapi.Depends(auth.get_auth_header),
-        portal_header: str
-        | None = fastapi.Header(None, alias=config.PORTAL_HEADER_NAME),
+        portal_header: str | None = fastapi.Header(
+            None, alias=config.PORTAL_HEADER_NAME
+        ),
     ) -> ogc_api_processes_fastapi.models.StatusInfo:
         """Implement OGC API - Processes `DELETE /jobs/{job_id}` endpoint.
 

--- a/cads_processing_api_service/models.py
+++ b/cads_processing_api_service/models.py
@@ -46,8 +46,13 @@ class StatusInfo(ogc_api_processes_fastapi.models.StatusInfo):
     log: list[str] | None = None
 
 
+class JobListAdditionalInfo(pydantic.BaseModel):
+    totalCount: int | None = None
+
+
 class JobList(ogc_api_processes_fastapi.models.JobList):
     jobs: list[StatusInfo]  # type: ignore
+    additionalInfo: JobListAdditionalInfo | None = None
 
 
 class Exception(ogc_api_processes_fastapi.models.Exception):


### PR DESCRIPTION
This PR adds a field to the `GET /jobs` endpoint response, reporting the total count of jobs found in the broker db taking into account the chosen filtering options.

This is an example response, with no jobs found:
```
{
    "jobs": [],
    "links": [
        {
            "href": "http://127.0.0.1:8080/api/retrieve/v1/jobs?limit=3&status=accepted",
            "rel": "self",
            "title": "list of submitted jobs"
        }
    ],
    "additionalInfo": {
        "totalCount": 0
    }
}
```

**Blocked by**
- https://github.com/ecmwf-projects/cads-broker/pull/89