### PR TITLE
Add qos_status to jobs list

### DIFF
--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -329,6 +329,11 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
                     job=job,
                     results=results,
                     dataset_metadata={"title": dataset_title},
+                    statistics={
+                        "qos_status": cads_broker.database.get_qos_status_from_request(
+                            job
+                        )
+                    },
                 )
             )
         job_list = models.JobList(


### PR DESCRIPTION
This PR adds qos_status statistics to each job in the response of `GET /jobs`. This is an example response:

```
{
    "jobs": [
        ...,
        {
            "processID": "reanalysis-era5-pressure-levels",
            "type": "process",
            "jobID": "157c7be1-27eb-4c4f-b2fe-b1311536e883",
            "status": "accepted",
            "created": "2023-11-14T17:05:48.400459",
            "updated": "2023-11-14T17:05:48.794105",
            "links": [
                {
                    "href": "http://127.0.0.1:8080/api/retrieve/v1/jobs/157c7be1-27eb-4c4f-b2fe-b1311536e883",
                    "rel": "monitor",
                    "type": "application/json",
                    "title": "job status info"
                }
            ],
            "results": {
                "type": "http://www.opengis.net/def/exceptions/ogcapi-processes-1/1.0/result-not-ready",
                "title": "job results not ready",
                "status": 404,
                "detail": "status of 157c7be1-27eb-4c4f-b2fe-b1311536e883 is 'accepted'",
                "trace_id": "b055cdc1-8cec-49fc-89da-387a1edfe621"
            },
            "processDescription": {
                "title": "ERA5 hourly data on pressure levels from 1940 to present"
            },
            "statistics": {
                "qos_status": {
                    "user": [
                        [
                            "Default per-user limit",
                            "2"
                        ]
                    ],
                    "limit": [
                        [
                            "Limit for reanalysis-era5-pressure-levels",
                            "2"
                        ]
                    ]
                }
            }
        },
        ....
    }
]
```