### PR TITLE
Add dataset's messages

### DIFF
--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -339,7 +339,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         job_list = models.JobList(
             jobs=jobs,
             links=[ogc_api_processes_fastapi.models.Link(href="")],
-            additionalInfo=models.JobListAdditionalInfo(totalCount=jobs_count),
+            metadata=models.JobListMetadata(totalCount=jobs_count),
         )
         pagination_query_params = utils.make_pagination_query_params(
             jobs, sort_key=sortby.lstrip("-")

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -202,6 +202,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
                 resource_id=process_id,
                 table=self.process_table,
                 session=catalogue_session,
+                load_messages=True,
             )
         adaptor = adaptors.instantiate_adaptor(resource)
         licences = adaptor.get_licences(execution_content)
@@ -225,7 +226,17 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
                 qos_tags=resource.qos_tags,
                 **job_kwargs,
             )
-        status_info = utils.make_status_info(job)
+        dataset_messages = [
+            models.DatasetMessage(
+                date=message.date,
+                severity=message.severity,
+                content=message.content,
+            )
+            for message in resource.messages
+        ]
+        status_info = utils.make_status_info(
+            job, dataset_metadata={"messages": dataset_messages}
+        )
         return status_info
 
     def get_jobs(

--- a/cads_processing_api_service/models.py
+++ b/cads_processing_api_service/models.py
@@ -25,7 +25,7 @@ class StatusInfoMetadata(pydantic.BaseModel):
     request: dict[str, Any] | None = None
     results: dict[str, Any] | None = None
     datasetMetadata: dict[str, Any] | None = None
-    statistics: dict[str, Any] | None = None
+    qos: dict[str, Any] | None = None
     log: list[str] | None = None
 
 

--- a/cads_processing_api_service/models.py
+++ b/cads_processing_api_service/models.py
@@ -14,27 +14,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
+import datetime
 from typing import Any
 
 import ogc_api_processes_fastapi.models
 import pydantic
 
 
-class StatusInfo(ogc_api_processes_fastapi.models.StatusInfo):
+class StatusInfoMetadata(pydantic.BaseModel):
     request: dict[str, Any] | None = None
     results: dict[str, Any] | None = None
-    processDescription: dict[str, Any] | None = None
+    datasetMetadata: dict[str, Any] | None = None
     statistics: dict[str, Any] | None = None
     log: list[str] | None = None
 
 
-class JobListAdditionalInfo(pydantic.BaseModel):
+class StatusInfo(ogc_api_processes_fastapi.models.StatusInfo):
+    metadata: StatusInfoMetadata | None = None
+
+
+class JobListMetadata(pydantic.BaseModel):
     totalCount: int | None = None
+
+
+class DatasetMessage(pydantic.BaseModel):
+    date: datetime.datetime | None = None
+    severity: str | None = None
+    content: str | None = None
+
+
+class DatasetMetadata(pydantic.BaseModel):
+    title: str | None = None
+    messages: list[DatasetMessage] | None = None
 
 
 class JobList(ogc_api_processes_fastapi.models.JobList):
     jobs: list[StatusInfo]  # type: ignore
-    additionalInfo: JobListAdditionalInfo | None = None
+    metadata: JobListMetadata | None = None
 
 
 class Exception(ogc_api_processes_fastapi.models.Exception):

--- a/cads_processing_api_service/utils.py
+++ b/cads_processing_api_service/utils.py
@@ -54,9 +54,10 @@ class JobSortCriterion(str, enum.Enum):
         maxsize=config.ensure_settings().cache_resources_maxsize,
         ttl=config.ensure_settings().cache_resources_ttl,
     ),
-    key=lambda resource_id, table, session, load_messages: cachetools.keys.hashkey(
-        resource_id, table, load_messages
-    ),
+    key=lambda resource_id,
+    table,
+    session,
+    load_messages=False: cachetools.keys.hashkey(resource_id, table, load_messages),
 )
 def lookup_resource_by_id(
     resource_id: str,

--- a/cads_processing_api_service/utils.py
+++ b/cads_processing_api_service/utils.py
@@ -54,7 +54,9 @@ class JobSortCriterion(str, enum.Enum):
         maxsize=config.ensure_settings().cache_resources_maxsize,
         ttl=config.ensure_settings().cache_resources_ttl,
     ),
-    key=lambda resource_id, table, session: cachetools.keys.hashkey(resource_id, table),
+    key=lambda resource_id, table, session, load_messages: cachetools.keys.hashkey(
+        resource_id, table, load_messages
+    ),
 )
 def lookup_resource_by_id(
     resource_id: str,

--- a/cads_processing_api_service/utils.py
+++ b/cads_processing_api_service/utils.py
@@ -60,6 +60,7 @@ def lookup_resource_by_id(
     resource_id: str,
     table: type[cads_catalogue.database.Resource],
     session: sqlalchemy.orm.Session,
+    load_messages: bool = False,
 ) -> cads_catalogue.database.Resource:
     """Look for the resource identified by `id` into the Catalogue database.
 
@@ -71,6 +72,8 @@ def lookup_resource_by_id(
         Catalogue database table.
     session : sqlalchemy.orm.Session
         Catalogue database session.
+    load_messages : bool, optional
+        If True, load resource messages, by default False.
 
     Returns
     -------
@@ -86,8 +89,10 @@ def lookup_resource_by_id(
         sa.select(table)
         .options(sqlalchemy.orm.joinedload(table.resource_data))
         .options(sqlalchemy.orm.joinedload(table.licences))
-        .filter(table.resource_uid == resource_id)
     )
+    if load_messages:
+        statement = statement.options(sqlalchemy.orm.joinedload(table.messages))
+    statement = statement.filter(table.resource_uid == resource_id)
     try:
         row: cads_catalogue.database.Resource = (
             session.execute(statement).unique().scalar_one()

--- a/cads_processing_api_service/utils.py
+++ b/cads_processing_api_service/utils.py
@@ -577,14 +577,11 @@ def make_status_info(
         finished=job["finished_at"],
         updated=job["updated_at"],
     )
-    if request:
-        status_info.request = request
-    if results:
-        status_info.results = results
-    if dataset_metadata:
-        status_info.processDescription = {"title": dataset_metadata["title"]}
-    if statistics:
-        status_info.statistics = statistics
-    if log is not None:
-        status_info.log = log
+    status_info.metadata = models.StatusInfoMetadata(
+        request=request,
+        results=results,
+        datasetMetadata=dataset_metadata,
+        statistics=statistics,
+        log=log,
+    )
     return status_info

--- a/tests/integration_test_10_clients.py
+++ b/tests/integration_test_10_clients.py
@@ -356,7 +356,7 @@ def test_get_job(dev_env_proc_api_url: str, dev_env_prof_api_url: str) -> None:
     assert response_body["status"] in exp_status
 
     request_url = urllib.parse.urljoin(
-        dev_env_proc_api_url, f"jobs/{job_id}?statistics=True&request=True&log=True"
+        dev_env_proc_api_url, f"jobs/{job_id}?qos=True&request=True&log=True"
     )
     response = requests.get(request_url, headers=AUTH_HEADERS_VALID_1)
     response_status_code = response.status_code
@@ -364,9 +364,12 @@ def test_get_job(dev_env_proc_api_url: str, dev_env_prof_api_url: str) -> None:
     assert response_status_code == exp_status_code
 
     response_body = response.json()
-    exp_add_keys = ("statistics", "request", "log")
-    assert all([key in response_body for key in exp_add_keys])
-    exp_statistics_keys = (
+    exp_add_key = "metadata"
+    assert exp_add_key in response_body
+    metadata = response_body["metadata"]
+    exp_metadata_keys = ("qos", "request", "log")
+    assert all([key in metadata for key in exp_metadata_keys])
+    exp_qos_keys = (
         "adaptor_entry_point",
         "running_requests_per_user_adaptor",
         "queued_requests_per_user_adaptor",
@@ -374,12 +377,12 @@ def test_get_job(dev_env_proc_api_url: str, dev_env_prof_api_url: str) -> None:
         "queued_requests_per_adaptor",
         "active_users_per_adaptor",
         "waiting_users_per_adaptor",
-        "qos_status",
+        "status",
     )
-    assert all([key in response_body["statistics"] for key in exp_statistics_keys])
+    assert all([key in metadata["qos"] for key in exp_qos_keys])
     exp_request_keys = ("ids", "labels")
-    assert all([key in response_body["request"] for key in exp_request_keys])
-    assert isinstance(response_body["log"], list)
+    assert all([key in metadata["request"] for key in exp_request_keys])
+    assert isinstance(metadata["log"], list)
 
     response = delete_job(dev_env_proc_api_url, job_id)
 


### PR DESCRIPTION
This PR:
- adds dataset's messages to `POST /processes/.../execution` response;
- refactor `StatusInfo` response

**Breaking Changes**
1) `GET /jobs/<jobID>` query parameter `statistics: bool` changes in `qos: bool`;
2) `processDescription` field in `GET /jobs/...` responses changes in `datasetMetadata`;
3) `statistics` field in `GET /jobs/...` responses changes in `qos`;
4) Job's status info fields `request`, `results`, `processDescription` (now `datasetMetadata`), `statistics` (now `qos`) and `log` are wrapped into the `metadata` field;
5) `qos_status` field inside the `statistics` (now `qos`) field changes in `status`.
6 `additionalInfo` field in `GET /jobs` response changes in `metadata`.

More details can be found at the dedicated [Confluence page](https://confluence.ecmwf.int/pages/viewpage.action?pageId=371034876).