### PR TITLE
Fix fastapi request

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,12 +12,12 @@ dependencies:
 - asyncpg
 - cachetools
 - DateTimeRange
-- fastapi>=0.93.0,<=0.105.0
+- fastapi>=0.93.0,<=0.108.0
 - pip
 - pydantic>2
 - pydantic-settings>2
 - sqlalchemy>=2.0.9
+# - starlette<=0.32.0
+- starlette-exporter
 - structlog
-- uvicorn
-- pip:
-  - starlette-exporter
+- uvicorn<=0.25.0

--- a/environment.yml
+++ b/environment.yml
@@ -12,11 +12,11 @@ dependencies:
 - asyncpg
 - cachetools
 - DateTimeRange
-- fastapi>=0.93.0,<=0.108.0
+- fastapi>=0.109.0
 - pip
 - pydantic>2
 - pydantic-settings>2
 - sqlalchemy>=2.0.9
 - starlette-exporter
 - structlog
-- uvicorn<=0.25.0
+- uvicorn>=0.26.0

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,6 @@ dependencies:
 - pydantic-settings>2
 - sqlalchemy>=2.0.9
 - starlette<=0.34
+- starlette-exporter
 - structlog
 - uvicorn
-- pip:
-  - starlette-exporter

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
 - pydantic>2
 - pydantic-settings>2
 - sqlalchemy>=2.0.9
-- starlette<0.35
+- starlette<=0.34
 - structlog
 - uvicorn
 - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,6 @@ dependencies:
 - pydantic>2
 - pydantic-settings>2
 - sqlalchemy>=2.0.9
-# - starlette<=0.32.0
 - starlette-exporter
 - structlog
 - uvicorn<=0.25.0

--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,7 @@ dependencies:
 - pydantic>2
 - pydantic-settings>2
 - sqlalchemy>=2.0.9
+- starlette<0.35
 - structlog
 - uvicorn
 - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -12,12 +12,12 @@ dependencies:
 - asyncpg
 - cachetools
 - DateTimeRange
-- fastapi>=0.93.0
+- fastapi>=0.93.0,<=0.105.0
 - pip
 - pydantic>2
 - pydantic-settings>2
 - sqlalchemy>=2.0.9
-- starlette<=0.34
-- starlette-exporter
 - structlog
 - uvicorn
+- pip:
+  - starlette-exporter

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
 - asyncpg
 - cachetools
 - DateTimeRange
-- fastapi>=0.93.0,<=0.105.0
+- fastapi>=0.93.0
 - pip
 - pydantic>2
 - pydantic-settings>2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,13 +19,14 @@ dependencies = [
   "cads-broker@git+https://github.com/ecmwf-projects/cads-broker.git",
   "cads-catalogue@git+https://github.com/ecmwf-projects/cads-catalogue.git",
   "cads-common@git+https://github.com/ecmwf-projects/cads-common.git",
-  "fastapi",
+  "fastapi>=0.93",
   "ogc-api-processes-fastapi@git+https://github.com/ecmwf-projects/ogc-api-processes-fastapi.git",
   "pydantic>2",
   "pydantic-settings>2",
   "prometheus_client",
   "requests",
   "sqlalchemy>=2.0.9",
+  "starlette<0.15",
   "starlette_exporter",
   "structlog"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "prometheus_client",
   "requests",
   "sqlalchemy>=2.0.9",
-  "starlette<0.15",
+  "starlette<=0.34",
   "starlette_exporter",
   "structlog"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,14 +19,13 @@ dependencies = [
   "cads-broker@git+https://github.com/ecmwf-projects/cads-broker.git",
   "cads-catalogue@git+https://github.com/ecmwf-projects/cads-catalogue.git",
   "cads-common@git+https://github.com/ecmwf-projects/cads-common.git",
-  "fastapi>=0.93",
+  "fastapi",
   "ogc-api-processes-fastapi@git+https://github.com/ecmwf-projects/ogc-api-processes-fastapi.git",
   "pydantic>2",
   "pydantic-settings>2",
   "prometheus_client",
   "requests",
   "sqlalchemy>=2.0.9",
-  "starlette<=0.34",
   "starlette_exporter",
   "structlog"
 ]


### PR DESCRIPTION
Rationale of the changes to the `environment.yml`:

1. `starlette-exporter` can be installed from conda
2. `uvicorn > 0.25.0` makes the application unreachable (all endpoints return a `404`)
3. `fastapi > 0.108.0` (or related `starlette` dependency upgrade) unexpectedly changes the behaviour of `fastapi.Request.url`, causing the links to e.g. `self`, `next` and `prev` not to be built properly (missing `/api/retrieve/v1` in tue URLs) -> since this logic is in `ogc-api-processes-fastapi` package, this should probably be moved there

**UPDATE 24-01-2024**

As per points 2. and 3., issues are solved also if BOTH `fastapi` and `uvicorn` are at their (current) latest versions (see https://github.com/encode/uvicorn/pull/2213 and https://github.com/tiangolo/fastapi/issues/10978)

-> `environment.yml` is changed accordingly