### PR TITLE
Costing endpoint

### DIFF
--- a/cads_processing_api_service/costing.py
+++ b/cads_processing_api_service/costing.py
@@ -1,0 +1,29 @@
+from typing import Any
+
+import cads_adaptors
+import cads_adaptors.constraints
+import cads_catalogue
+import fastapi
+
+from . import adaptors, db_utils, exceptions, utils
+
+
+def estimate_costing(
+    process_id: str = fastapi.Path(...),
+    request: dict[str, Any] = fastapi.Body(...),
+) -> dict[str, Any]:
+    table = cads_catalogue.database.Resource
+    catalogue_sessionmaker = db_utils.get_catalogue_sessionmaker(
+        db_utils.ConnectionMode.read
+    )
+    with catalogue_sessionmaker() as catalogue_session:
+        dataset = utils.lookup_resource_by_id(
+            resource_id=process_id, table=table, session=catalogue_session
+        )
+    adaptor: cads_adaptors.AbstractAdaptor = adaptors.instantiate_adaptor(dataset)
+    try:
+        costing: dict[str, Any] = adaptor.estimate_costing(request=request)
+    except cads_adaptors.constraints.ParameterError as exc:
+        raise exceptions.InvalidParameter(detail=str(exc))
+
+    return costing

--- a/cads_processing_api_service/costing.py
+++ b/cads_processing_api_service/costing.py
@@ -4,13 +4,14 @@ import cads_adaptors
 import cads_adaptors.constraints
 import cads_catalogue
 import fastapi
+import ogc_api_processes_fastapi.models
 
 from . import adaptors, db_utils, exceptions, utils
 
 
 def estimate_costing(
     process_id: str = fastapi.Path(...),
-    request: dict[str, Any] = fastapi.Body(...),
+    request: ogc_api_processes_fastapi.models.Execute = fastapi.Body(...),
 ) -> dict[str, Any]:
     table = cads_catalogue.database.Resource
     catalogue_sessionmaker = db_utils.get_catalogue_sessionmaker(
@@ -22,7 +23,7 @@ def estimate_costing(
         )
     adaptor: cads_adaptors.AbstractAdaptor = adaptors.instantiate_adaptor(dataset)
     try:
-        costing: dict[str, Any] = adaptor.estimate_costing(request=request)
+        costing: dict[str, Any] = adaptor.estimate_costing(request=request.model_dump())
     except cads_adaptors.constraints.ParameterError as exc:
         raise exceptions.InvalidParameter(detail=str(exc))
 

--- a/cads_processing_api_service/costing.py
+++ b/cads_processing_api_service/costing.py
@@ -23,7 +23,7 @@ def estimate_costs(
         )
         adaptor_configuration: dict[
             str, Any
-        ] = dataset.resource_data.adaptor_configuration
+        ] = dataset.resource_data.adaptor_configuration  # type: ignore
     costing_config: dict[str, Any] = adaptor_configuration.get("costing", {})
     max_costs: dict[str, Any] = costing_config.get("max_costs", {})
     adaptor: cads_adaptors.AbstractAdaptor = adaptors.instantiate_adaptor(dataset)

--- a/cads_processing_api_service/costing.py
+++ b/cads_processing_api_service/costing.py
@@ -9,7 +9,7 @@ import ogc_api_processes_fastapi.models
 from . import adaptors, db_utils, models, utils
 
 
-def estimate_costing(
+def estimate_costs(
     process_id: str = fastapi.Path(...),
     request: ogc_api_processes_fastapi.models.Execute = fastapi.Body(...),
 ) -> models.Costing:
@@ -27,7 +27,7 @@ def estimate_costing(
     costing_config: dict[str, Any] = adaptor_configuration.get("costing", {})
     max_costs: dict[str, Any] = costing_config.get("max_costs", {})
     adaptor: cads_adaptors.AbstractAdaptor = adaptors.instantiate_adaptor(dataset)
-    costs: dict[str, float] = adaptor.estimate_costing(request=request.model_dump())
+    costs: dict[str, float] = adaptor.estimate_costs(request=request.model_dump())
     max_costs_exceeded = {}
     for max_cost_id, max_cost_value in max_costs.items():
         if max_cost_id in costs.keys():

--- a/cads_processing_api_service/costing.py
+++ b/cads_processing_api_service/costing.py
@@ -6,13 +6,13 @@ import cads_catalogue
 import fastapi
 import ogc_api_processes_fastapi.models
 
-from . import adaptors, db_utils, exceptions, utils
+from . import adaptors, db_utils, models, utils
 
 
 def estimate_costing(
     process_id: str = fastapi.Path(...),
     request: ogc_api_processes_fastapi.models.Execute = fastapi.Body(...),
-) -> dict[str, Any]:
+) -> models.Costing:
     table = cads_catalogue.database.Resource
     catalogue_sessionmaker = db_utils.get_catalogue_sessionmaker(
         db_utils.ConnectionMode.read
@@ -21,10 +21,18 @@ def estimate_costing(
         dataset = utils.lookup_resource_by_id(
             resource_id=process_id, table=table, session=catalogue_session
         )
+        adaptor_configuration: dict[
+            str, Any
+        ] = dataset.resource_data.adaptor_configuration
+    costing_config: dict[str, Any] = adaptor_configuration.get("costing", {})
+    max_costs: dict[str, Any] = costing_config.get("max_costs", {})
     adaptor: cads_adaptors.AbstractAdaptor = adaptors.instantiate_adaptor(dataset)
-    try:
-        costing: dict[str, Any] = adaptor.estimate_costing(request=request.model_dump())
-    except cads_adaptors.constraints.ParameterError as exc:
-        raise exceptions.InvalidParameter(detail=str(exc))
+    costs: dict[str, float] = adaptor.estimate_costing(request=request.model_dump())
+    max_costs_exceeded = {}
+    for max_cost_id, max_cost_value in max_costs.items():
+        if max_cost_id in costs.keys():
+            if costs[max_cost_id] > max_cost_value:
+                max_costs_exceeded[max_cost_id] = max_cost_value
+    costing = models.Costing(costs=costs, max_costs_exceeded=max_costs_exceeded)
 
     return costing

--- a/cads_processing_api_service/main.py
+++ b/cads_processing_api_service/main.py
@@ -26,7 +26,7 @@ import ogc_api_processes_fastapi
 import starlette_exporter
 import structlog
 
-from . import clients, constraints, exceptions, middlewares, translators
+from . import clients, constraints, costing, exceptions, middlewares, translators
 
 
 def add_user_request_flag(
@@ -57,6 +57,11 @@ app.router.lifespan_context = lifespan
 app.router.add_api_route(
     "/processes/{process_id}/constraints",
     constraints.apply_constraints,
+    methods=["POST"],
+)
+app.router.add_api_route(
+    "/processes/{process_id}/costing",
+    costing.estimate_costing,
     methods=["POST"],
 )
 app.router.add_api_route(

--- a/cads_processing_api_service/main.py
+++ b/cads_processing_api_service/main.py
@@ -61,7 +61,7 @@ app.router.add_api_route(
 )
 app.router.add_api_route(
     "/processes/{process_id}/costing",
-    costing.estimate_costing,
+    costing.estimate_costs,
     methods=["POST"],
 )
 app.router.add_api_route(

--- a/cads_processing_api_service/models.py
+++ b/cads_processing_api_service/models.py
@@ -56,3 +56,8 @@ class JobList(ogc_api_processes_fastapi.models.JobList):
 class Exception(ogc_api_processes_fastapi.models.Exception):
     trace_id: str | None = None
     traceback: str | None = None
+
+
+class Costing(pydantic.BaseModel):
+    costs: dict[str, float] | None = None
+    max_costs_exceeded: dict[str, float] | None = None

--- a/tests/integration_test_10_clients.py
+++ b/tests/integration_test_10_clients.py
@@ -730,7 +730,7 @@ def test_delete_job(dev_env_proc_api_url: str, dev_env_prof_api_url: str) -> Non
     assert response_status_code == exp_status_code
 
 
-def test_delete_job_not_athorized(
+def test_delete_job_not_authorized(
     dev_env_proc_api_url: str, dev_env_prof_api_url: str
 ) -> None:
     response = accept_licence(dev_env_prof_api_url)
@@ -761,7 +761,7 @@ def test_delete_job_not_athorized(
     response = delete_job(dev_env_proc_api_url, job_id)
 
 
-def test_constraints(dev_env_proc_api_url: str) -> None:
+def test_post_constraints(dev_env_proc_api_url: str) -> None:
     process_id = EXISTING_PROCESS_ID
     request_url = urllib.parse.urljoin(
         dev_env_proc_api_url, f"processes/{process_id}/constraints"
@@ -774,3 +774,23 @@ def test_constraints(dev_env_proc_api_url: str) -> None:
     )
 
     assert response.status_code == 200
+
+
+def test_post_costing(dev_env_proc_api_url: str) -> None:
+    process_id = EXISTING_PROCESS_ID
+    request_url = urllib.parse.urljoin(
+        dev_env_proc_api_url, f"processes/{process_id}/costing"
+    )
+    request_body: dict[str, dict[str, Any]] = {
+        "inputs": {"years": ["1971", "1972"], "months": ["01", "02"]}
+    }
+
+    response = requests.post(
+        request_url,
+        json=request_body,
+    )
+
+    assert response.status_code == 200
+    response_body = response.json()
+    assert "costs" in response_body
+    assert "max_costs_exceeded" in response_body


### PR DESCRIPTION
This PR implements costing endpoint.

The costing endpoint take as body a request's json and return something like:

```
{
    "costs": {
        "number_of_values": 100.0
    },
    "max_costs_exceeded": {}
}
```

where `max_costs_exceeded` is populated with sets of key-value pairs only if one of the costs limits (defined in the `adaptor.json` file of the corresponding dataset, is exceeded. As an example:

```
{
    "costs": {
        "number_of_values": 100000.0
    },
    "max_costs_exceeded": {
       "number_of_values": 1000.0
    }
}
```