### PR TITLE
Add check for disabled datasets

### DIFF
--- a/cads_processing_api_service/auth.py
+++ b/cads_processing_api_service/auth.py
@@ -268,3 +268,5 @@ def verify_if_disabled(
         raise exceptions.PermissionDenied(
             detail=dataset.disabled_reason,
         )
+    else:
+        return

--- a/cads_processing_api_service/auth.py
+++ b/cads_processing_api_service/auth.py
@@ -19,7 +19,6 @@ from typing import Any
 
 import cachetools
 import cads_broker
-import cads_catalogue.database
 import fastapi
 import requests
 
@@ -247,26 +246,24 @@ def validate_licences(
     check_licences(required_licences, accepted_licences)  # type: ignore
 
 
-def verify_if_disabled(
-    dataset: cads_catalogue.database.Resource, user_role: str | None
-) -> None:
-    """Verify if a dataset is disabled for the provided user role.
+def verify_if_disabled(disabled_reason: str | None, user_role: str | None) -> None:
+    """Verify if a dataset's disabling reason grant access to the dataset for a specific user role.
 
     Parameters
     ----------
-    dataset : cads_catalogue.database.Resource
-        Dataset description.
+    disabled_reason : str | None
+        Dataset's disabling reason.
     user_role : str | None
         User role.
 
     Raises
     ------
     exceptions.PermissionDenied
-        Raised if the user has no permission to interact with the dataset.
+        Raised if the user role has no permission to interact with the dataset.
     """
-    if dataset.disabled_reason and user_role != "manager":
+    if disabled_reason and user_role != "manager":
         raise exceptions.PermissionDenied(
-            detail=dataset.disabled_reason,
+            detail=disabled_reason,
         )
     else:
         return

--- a/cads_processing_api_service/auth.py
+++ b/cads_processing_api_service/auth.py
@@ -82,7 +82,7 @@ def get_auth_header(
 )
 def authenticate_user(
     auth_header: tuple[str, str], portal_header: str | None = None
-) -> tuple[str, str] | None:
+) -> tuple[str | None, str | None]:
     """Verify user authentication.
 
     Verify if the provided authentication header corresponds to a registered user.

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -205,7 +205,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
                 session=catalogue_session,
                 load_messages=True,
             )
-        auth.verify_if_disabled(resource, user_role)
+        auth.verify_if_disabled(resource.disabled_reason, user_role)
         adaptor = adaptors.instantiate_adaptor(resource)
         licences = adaptor.get_licences(execution_content)
         auth.validate_licences(accepted_licences, licences)

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -191,7 +191,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         models.StatusInfo
             Submitted job's status information.
         """
-        user_uid = auth.authenticate_user(auth_header, portal_header)
+        user_uid, user_role = auth.authenticate_user(auth_header, portal_header)
         structlog.contextvars.bind_contextvars(user_uid=user_uid)
         accepted_licences = auth.get_accepted_licences(auth_header)
         execution_content = execution_content.model_dump()
@@ -205,6 +205,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
                 session=catalogue_session,
                 load_messages=True,
             )
+        auth.verify_if_disabled(resource, user_role)
         adaptor = adaptors.instantiate_adaptor(resource)
         licences = adaptor.get_licences(execution_content)
         auth.validate_licences(accepted_licences, licences)
@@ -286,7 +287,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         models.JobList
             List of jobs status information.
         """
-        user_uid = auth.authenticate_user(auth_header, portal_header)
+        user_uid, _ = auth.authenticate_user(auth_header, portal_header)
         portals = [p.strip() for p in portal_header.split(",")]
         job_filters = {
             "process_id": processID,
@@ -403,7 +404,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         models.StatusInfo
             Job status information.
         """
-        user_uid = auth.authenticate_user(auth_header, portal_header)
+        user_uid, _ = auth.authenticate_user(auth_header, portal_header)
         portals = [p.strip() for p in portal_header.split(",")]
         try:
             compute_sessionmaker = db_utils.get_compute_sessionmaker(
@@ -504,7 +505,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
             Job results.
         """
         structlog.contextvars.bind_contextvars(job_id=job_id)
-        user_uid = auth.authenticate_user(auth_header, portal_header)
+        user_uid, _ = auth.authenticate_user(auth_header, portal_header)
         structlog.contextvars.bind_contextvars(user_id=user_uid)
         try:
             compute_sessionmaker = db_utils.get_compute_sessionmaker(
@@ -557,7 +558,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
             Job status information
         """
         structlog.contextvars.bind_contextvars(job_id=job_id)
-        user_uid = auth.authenticate_user(auth_header, portal_header)
+        user_uid, _ = auth.authenticate_user(auth_header, portal_header)
         structlog.contextvars.bind_contextvars(user_id=user_uid)
         compute_sessionmaker = db_utils.get_compute_sessionmaker(
             mode=db_utils.ConnectionMode.write

--- a/tests/test_30_auth.py
+++ b/tests/test_30_auth.py
@@ -43,3 +43,18 @@ def test_verify_permission() -> None:
     user_uid = "def456"
     with pytest.raises(exceptions.PermissionDenied):
         auth.verify_permission(user_uid, job)
+
+
+def test_verify_if_disabled() -> None:
+    test_disabled_reason = "test_disabled_reason"
+    test_user_role = None
+    with pytest.raises(exceptions.PermissionDenied):
+        auth.verify_if_disabled(test_disabled_reason, test_user_role)
+
+    test_disabled_reason = "test_disabled_reason"
+    test_user_role = "manager"
+    auth.verify_if_disabled(test_disabled_reason, test_user_role)
+
+    test_disabled_reason = None
+    test_user_role = None
+    auth.verify_if_disabled(test_disabled_reason, test_user_role)


### PR DESCRIPTION
This PR implements check for disabled datasets.

The `POST /processes/<process_id>/execute` endpoint checks if the dataset identified by the `process_id` has a `disabled_reason` != `None` and, in case, returns a `403` error if the role of the submitting user is != `manager`.

**Needs**

- https://github.com/ecmwf-projects/cads-extended-profiles/pull/58