### PR TITLE
Remove traceback from error messages

### DIFF
--- a/cads_processing_api_service/exceptions.py
+++ b/cads_processing_api_service/exceptions.py
@@ -81,7 +81,6 @@ def format_exception_content(
         detail=exc.detail,
         instance=instance,
         trace_id=structlog.contextvars.get_contextvars().get("trace_id", "unset"),
-        traceback=exc.traceback,
     ).model_dump(exclude_none=True)
 
     return exception_content
@@ -172,9 +171,6 @@ def general_exception_handler(
             type="internal server error",
             title="internal server error",
             trace_id=structlog.contextvars.get_contextvars().get("trace_id", "unset"),
-            traceback="".join(
-                traceback.TracebackException.from_exception(exc).format()
-            ),
         ).model_dump(exclude_none=True),
     )
 


### PR DESCRIPTION
This PR removes traceback from error messages returned by the Processing API.