### PR TITLE
Add cads-adaptors dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
 - cachetools
 - DateTimeRange
 - fastapi>=0.109.0
+- jsonschema
 - pip
 - pydantic>2
 - pydantic-settings>2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "cads-catalogue@git+https://github.com/ecmwf-projects/cads-catalogue.git",
   "cads-common@git+https://github.com/ecmwf-projects/cads-common.git",
   "fastapi",
+  "jsonschema",
   "ogc-api-processes-fastapi@git+https://github.com/ecmwf-projects/ogc-api-processes-fastapi.git",
   "pydantic>2",
   "pydantic-settings>2",


### PR DESCRIPTION
This PR adds cads-adaptors `jsonchema` dependency, needed to use the cds adaptor `normalise_request` method introduced in https://github.com/ecmwf-projects/cads-adaptors/pull/152.