### PR TITLE
Let anonymous user submit jobs but return disclaimer

### DIFF
--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -204,7 +204,6 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         """
         user_uid, user_role = auth.authenticate_user(auth_header, portal_header)
         structlog.contextvars.bind_contextvars(user_uid=user_uid)
-        accepted_licences = auth.get_accepted_licences(auth_header)
         request = execution_content.model_dump()
         catalogue_sessionmaker = db_utils.get_catalogue_sessionmaker(
             db_utils.ConnectionMode.read
@@ -234,6 +233,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         auth.verify_cost(request_inputs, adaptor_properties)
         licences = adaptor.get_licences(request_inputs)
         if user_uid != "anonymous":
+            accepted_licences = auth.get_accepted_licences(auth_header)
             auth.validate_licences(accepted_licences, licences)
             job_message = None
         else:

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -237,7 +237,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
             auth.validate_licences(accepted_licences, licences)
             job_message = None
         else:
-            job_message = config.ANONYMOUS_LICENCES_MESSAGE.format(
+            job_message = config.ensure_settings().anonymous_licences_message.format(
                 licences="; ".join(
                     [f"{licence[0]} (rev: {licence[1]})" for licence in licences]
                 )

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -237,7 +237,11 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
             auth.validate_licences(accepted_licences, licences)
             job_message = None
         else:
-            job_message = config.ANONYMOUS_LICENCES_MESSAGE
+            job_message = config.ANONYMOUS_LICENCES_MESSAGE.format(
+                licences="; ".join(
+                    [f"{licence[0]} (rev: {licence[1]})" for licence in licences]
+                )
+            )
         job_id = str(uuid.uuid4())
         structlog.contextvars.bind_contextvars(job_id=job_id)
         job_kwargs = adaptors.make_system_job_kwargs(

--- a/cads_processing_api_service/config.py
+++ b/cads_processing_api_service/config.py
@@ -54,7 +54,7 @@ class Settings(pydantic_settings.BaseSettings):
 
     api_request_template: str = API_REQUEST_TEMPLATE
     missing_dataset_title: str = "Dataset not available"
-    anonymous_licences_message: str = "Anonymous licences are not allowed"
+    anonymous_licences_message: str = ANONYMOUS_LICENCES_MESSAGE
 
     @property
     def profiles_api_url(self) -> str:

--- a/cads_processing_api_service/config.py
+++ b/cads_processing_api_service/config.py
@@ -28,7 +28,11 @@ client = cdsapi.Client()
 client.retrieve(dataset, request).download()
 """
 
-ANONYMOUS_LICENCES_MESSAGE = "The job has been submitted as an anonymous user."
+ANONYMOUS_LICENCES_MESSAGE = (
+    "The job has been submitted as an anonymous user. "
+    "Please consider the following licences implicitly accepted: "
+    "{licences}"
+)
 
 general_settings = None
 

--- a/cads_processing_api_service/config.py
+++ b/cads_processing_api_service/config.py
@@ -28,6 +28,8 @@ client = cdsapi.Client()
 client.retrieve(dataset, request).download()
 """
 
+ANONYMOUS_LICENCES_MESSAGE = "The job has been submitted as an anonymous user."
+
 general_settings = None
 
 
@@ -48,6 +50,7 @@ class Settings(pydantic_settings.BaseSettings):
 
     api_request_template: str = API_REQUEST_TEMPLATE
     missing_dataset_title: str = "Dataset not available"
+    anonymous_licences_message: str = "Anonymous licences are not allowed"
 
     @property
     def profiles_api_url(self) -> str:


### PR DESCRIPTION
This PR let anonymous user bypass licences verification when submitting processes, but add a disclaimer message to the response warning that some licences are implicitly accepted.

**Needed by**:
- https://github.com/ecmwf-projects/cads-api-client/pull/53