### PR TITLE
Enable different max costs (WEB/API)

### DIFF
--- a/cads_processing_api_service/auth.py
+++ b/cads_processing_api_service/auth.py
@@ -286,7 +286,7 @@ def verify_cost(
     exceptions.PermissionDenied
         Raised if the cost of the process execution request exceeds the allowed limits.
     """
-    costing_info = costing.compute_costing(request, adaptor_properties)
+    costing_info = costing.compute_costing(request, adaptor_properties, request_origin)
     max_costs_exceeded = costing_info.max_costs_exceeded
     if max_costs_exceeded:
         raise exceptions.PermissionDenied(

--- a/cads_processing_api_service/auth.py
+++ b/cads_processing_api_service/auth.py
@@ -267,7 +267,9 @@ def verify_if_disabled(disabled_reason: str | None, user_role: str | None) -> No
         return
 
 
-def verify_cost(request: dict[str, Any], adaptor_properties: dict[str, Any]) -> None:
+def verify_cost(
+    request: dict[str, Any], adaptor_properties: dict[str, Any], request_origin: str
+) -> None:
     """Verify if the cost of a process execution request is within the allowed limits.
 
     Parameters
@@ -276,6 +278,8 @@ def verify_cost(request: dict[str, Any], adaptor_properties: dict[str, Any]) -> 
         Process execution request.
     adaptor_properties : dict[str, Any]
         Adaptor properties.
+    request_origin : str
+        Origin of the request. Can be either "api" or "ui".
 
     Raises
     ------

--- a/cads_processing_api_service/costing.py
+++ b/cads_processing_api_service/costing.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 
+import enum
 from typing import Any
 
 import cads_adaptors
@@ -25,9 +26,14 @@ from . import adaptors, costing, db_utils, models, utils
 COST_THRESHOLDS = {"api": "max_costs", "ui": "max_costs_portal"}
 
 
+class RequestOrigin(str, enum.Enum):
+    api: str = "api"
+    ui: str = "ui"
+
+
 def estimate_costs(
     process_id: str = fastapi.Path(...),
-    request_origin: str = fastapi.Query("api"),
+    request_origin: RequestOrigin = fastapi.Query("api"),
     execution_content: models.Execute = fastapi.Body(...),
 ) -> models.Costing:
     request = execution_content.model_dump()

--- a/cads_processing_api_service/costing.py
+++ b/cads_processing_api_service/costing.py
@@ -62,7 +62,7 @@ def compute_costing(
     )
     if request_origin not in COST_THRESHOLDS:
         raise ValueError(f"Invalid request origin: {request_origin}")
-    cost_threshold: str = COST_THRESHOLDS.get(request_origin)
+    cost_threshold = COST_THRESHOLDS[request_origin]
     costs: dict[str, float] = adaptor.estimate_costs(
         request=request, cost_threshold=cost_threshold
     )

--- a/cads_processing_api_service/costing.py
+++ b/cads_processing_api_service/costing.py
@@ -27,7 +27,7 @@ COST_THRESHOLDS = {"api": "max_costs", "ui": "max_costs_portal"}
 
 def estimate_costs(
     process_id: str = fastapi.Path(...),
-    request_origin: str | None = fastapi.Query("api"),
+    request_origin: str = fastapi.Query("api"),
     execution_content: models.Execute = fastapi.Body(...),
 ) -> models.Costing:
     request = execution_content.model_dump()
@@ -54,7 +54,9 @@ def compute_costing(
     adaptor: cads_adaptors.AbstractAdaptor = adaptors.instantiate_adaptor(
         adaptor_properties=adaptor_properties
     )
-    cost_threshold = COST_THRESHOLDS.get(request_origin)
+    if request_origin not in COST_THRESHOLDS:
+        raise ValueError(f"Invalid request origin: {request_origin}")
+    cost_threshold: str = COST_THRESHOLDS.get(request_origin)
     costs: dict[str, float] = adaptor.estimate_costs(
         request=request, cost_threshold=cost_threshold
     )

--- a/cads_processing_api_service/costing.py
+++ b/cads_processing_api_service/costing.py
@@ -27,6 +27,7 @@ COST_THRESHOLDS = {"api": "max_costs", "ui": "max_costs_portal"}
 
 def estimate_costs(
     process_id: str = fastapi.Path(...),
+    request_origin: str | None = fastapi.Query("api"),
     execution_content: models.Execute = fastapi.Body(...),
 ) -> models.Costing:
     request = execution_content.model_dump()
@@ -40,7 +41,7 @@ def estimate_costs(
         )
     adaptor_properties = adaptors.get_adaptor_properties(dataset)
     costing_info = costing.compute_costing(
-        request.get("inputs", {}), adaptor_properties
+        request.get("inputs", {}), adaptor_properties, request_origin
     )
     return costing_info
 
@@ -53,7 +54,7 @@ def compute_costing(
     adaptor: cads_adaptors.AbstractAdaptor = adaptors.instantiate_adaptor(
         adaptor_properties=adaptor_properties
     )
-    cost_threshold = COST_THRESHOLDS.get(request_origin, "max_costs")
+    cost_threshold = COST_THRESHOLDS.get(request_origin)
     costs: dict[str, float] = adaptor.estimate_costs(
         request=request, cost_threshold=cost_threshold
     )

--- a/tests/test_30_auth.py
+++ b/tests/test_30_auth.py
@@ -70,11 +70,11 @@ def test_verify_cost() -> None:
             costs={"cost_1": 1.0, "cost_2": 2.0},
             max_costs_exceeded={},
         )
-        auth.verify_cost({}, {})
+        auth.verify_cost({}, {}, "api")
 
         mock_compute_costing.return_value = models.Costing(
             costs={"cost_1": 1.0, "cost_2": 2.0},
             max_costs_exceeded={"cost_1": 0},
         )
         with pytest.raises(exceptions.PermissionDenied):
-            auth.verify_cost({}, {})
+            auth.verify_cost({}, {}, "api")


### PR DESCRIPTION
This PR implements taking into account requests' origin in costing evaluation.

It also introduces a new query parameter, `request_origin`, to the `/processes/<process_id>/costing` endpoint.

**IMPORTANT NOTE**
The request origins (either  `api` or `ui`) are associated respectively with the content of the keys `max_costs` and `max_costs_portal` in the `costing` field of each dataset's `adaptor.json` file.

**Needs**
- https://github.com/ecmwf-projects/cads-adaptors/pull/173