### PR TITLE
Remove licences cache

### DIFF
--- a/cads_processing_api_service/auth.py
+++ b/cads_processing_api_service/auth.py
@@ -150,12 +150,6 @@ def verify_permission(user_uid: str, job: cads_broker.SystemRequest) -> None:
         )
 
 
-@cachetools.cached(
-    cache=cachetools.TTLCache(
-        maxsize=config.ensure_settings().cache_users_maxsize,
-        ttl=config.ensure_settings().cache_users_ttl,
-    ),
-)
 def get_accepted_licences(auth_header: tuple[str, str]) -> set[tuple[str, int]]:
     """Get licences accepted by a user stored in the Extended Profiles database.
 

--- a/tests/test_30_utils.py
+++ b/tests/test_30_utils.py
@@ -116,8 +116,8 @@ def test_apply_bookmark() -> None:
         statement, job_table, cursor, back, sort_key, sort_dir
     )
     compiled_statement = statement.compile()
-    exp_params = {"created_at_1": "2022-10-24 13:32:03.178397"}
-    exp_substatement = "WHERE system_requests.created_at > :created_at_1"
+    exp_params = {"created_at_2": "2022-10-24 13:32:03.178397"}
+    exp_substatement = "WHERE system_requests.created_at > :created_at_2"
     assert compiled_statement.params == exp_params
     assert exp_substatement in compiled_statement.string
 


### PR DESCRIPTION
Remove `get_accepted_licences` cache to ensure process submission tight after licences acceptance doesn't get blocked.