### PR TITLE
Add warning message for deprecated /execute endpoint

### DIFF
--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -177,6 +177,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
 
     def post_process_execution(
         self,
+        api_request: fastapi.Request,
         process_id: str = fastapi.Path(...),
         execution_content: models.Execute = fastapi.Body(...),
         auth_header: tuple[str, str] = fastapi.Depends(auth.get_auth_header),
@@ -273,6 +274,16 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         status_info = utils.make_status_info(
             job, dataset_metadata={"messages": dataset_messages}
         )
+        url = str(api_request.url)
+        if url.rstrip("/").endswith("execute"):
+            log_message = (
+                datetime.datetime.now().isoformat(),
+                config.ensure_settings().deprecation_warning_message,
+            )
+            if status_info.metadata.log is None:
+                status_info.metadata.log = [log_message]
+            else:
+                status_info.metadata.log.append(log_message)
         status_info.message = job_message
         return status_info
 

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -271,19 +271,17 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
             )
             for message in dataset.messages
         ]
+        url = str(api_request.url)
+        if url.rstrip("/").endswith("execute"):
+            message = models.DatasetMessage(
+                date=datetime.datetime.now(),
+                severity="WARNING",
+                content=config.ensure_settings().deprecation_warning_message,
+            )
+            dataset_messages.append(message)
         status_info = utils.make_status_info(
             job, dataset_metadata={"messages": dataset_messages}
         )
-        url = str(api_request.url)
-        if url.rstrip("/").endswith("execute"):
-            log_message = (
-                datetime.datetime.now().isoformat(),
-                config.ensure_settings().deprecation_warning_message,
-            )
-            if status_info.metadata.log is None:
-                status_info.metadata.log = [log_message]
-            else:
-                status_info.metadata.log.append(log_message)
         status_info.message = job_message
         return status_info
 

--- a/cads_processing_api_service/config.py
+++ b/cads_processing_api_service/config.py
@@ -34,6 +34,12 @@ ANONYMOUS_LICENCES_MESSAGE = (
     "{licences}"
 )
 
+DEPRECATION_WARNING_MESSAGE = (
+    "WARNING: The version of cdsapi you are using makes use of a "
+    "deprecated CADS Processing API endpoint; "
+    "Please upgrade to cdsapi>=...."
+)
+
 general_settings = None
 
 
@@ -57,6 +63,7 @@ class Settings(pydantic_settings.BaseSettings):
     api_request_template: str = API_REQUEST_TEMPLATE
     missing_dataset_title: str = "Dataset not available"
     anonymous_licences_message: str = ANONYMOUS_LICENCES_MESSAGE
+    deprecation_warning_message: str = DEPRECATION_WARNING_MESSAGE
 
     @property
     def profiles_api_url(self) -> str:

--- a/cads_processing_api_service/config.py
+++ b/cads_processing_api_service/config.py
@@ -35,8 +35,8 @@ ANONYMOUS_LICENCES_MESSAGE = (
 )
 
 DEPRECATION_WARNING_MESSAGE = (
-    "WARNING: The version of cdsapi you are using makes use of a "
-    "deprecated CADS Processing API endpoint."
+    "You are using a deprecated API endpoint. "
+    "If you are using cdsapi, please upgrade to the latest version."
 )
 
 general_settings = None

--- a/cads_processing_api_service/config.py
+++ b/cads_processing_api_service/config.py
@@ -36,8 +36,7 @@ ANONYMOUS_LICENCES_MESSAGE = (
 
 DEPRECATION_WARNING_MESSAGE = (
     "WARNING: The version of cdsapi you are using makes use of a "
-    "deprecated CADS Processing API endpoint; "
-    "Please upgrade to cdsapi>=...."
+    "deprecated CADS Processing API endpoint."
 )
 
 general_settings = None


### PR DESCRIPTION
This PR adds a warning dataset message to port_process_execution responses in case the URL of the API request ends with `/execute` (deprecated). The warning is addressed to cdsapi client's users, and should suggest to update it to a recent version where the `execution` endpoint is used instead.