### PR TITLE
Refactor /costing endpoint

### DIFF
--- a/cads_processing_api_service/auth.py
+++ b/cads_processing_api_service/auth.py
@@ -289,7 +289,7 @@ def verify_cost(
     highest_cost: models.RequestCost = costing.compute_highest_cost_limit_ratio(
         costing_info
     )
-    if highest_cost.cost > highest_cost.cost_limit:
+    if highest_cost.cost > highest_cost.limit:
         raise exceptions.PermissionDenied(
             title="cost limits exceeded",
             detail="Your request is too large, please reduce your selection.",

--- a/cads_processing_api_service/auth.py
+++ b/cads_processing_api_service/auth.py
@@ -22,7 +22,7 @@ import cads_broker
 import fastapi
 import requests
 
-from . import config, costing, exceptions
+from . import config, costing, exceptions, models
 
 VERIFICATION_ENDPOINT = {
     "PRIVATE-TOKEN": "/account/verification/pat",
@@ -283,9 +283,11 @@ def verify_cost(
     dict[str, float] | None
         Request costs.
     """
-    costing_info = costing.compute_costing(request, adaptor_properties)
-    max_costs_exceeded = costing_info.max_costs_exceeded
-    if max_costs_exceeded:
+    costing_info: models.CostingInfo = costing.compute_costing(
+        request, adaptor_properties
+    )
+    limits_exceeded = costing_info.limits_exceeded
+    if limits_exceeded:
         raise exceptions.PermissionDenied(
             title="cost limits exceeded",
             detail="Your request is too large, please reduce your selection.",

--- a/cads_processing_api_service/auth.py
+++ b/cads_processing_api_service/auth.py
@@ -286,8 +286,10 @@ def verify_cost(
     costing_info: models.CostingInfo = costing.compute_costing(
         request, adaptor_properties
     )
-    limits_exceeded = costing_info.limits_exceeded
-    if limits_exceeded:
+    highest_cost: models.RequestCost = costing.compute_highest_cost_limit_ratio(
+        costing_info
+    )
+    if highest_cost.cost > highest_cost.cost_limit:
         raise exceptions.PermissionDenied(
             title="cost limits exceeded",
             detail="Your request is too large, please reduce your selection.",

--- a/cads_processing_api_service/auth.py
+++ b/cads_processing_api_service/auth.py
@@ -286,7 +286,7 @@ def verify_cost(
         Request costs.
     """
     costing_info: models.CostingInfo = costing.compute_costing(
-        request, adaptor_properties
+        request, adaptor_properties, request_origin
     )
     highest_cost: models.RequestCost = costing.compute_highest_cost_limit_ratio(
         costing_info

--- a/cads_processing_api_service/costing.py
+++ b/cads_processing_api_service/costing.py
@@ -78,6 +78,7 @@ def compute_highest_cost_limit_ratio(
     costs = costing_info.costs
     limits = costing_info.limits
     highest_cost_limit_ratio = 0
+    highest_cost = models.RequestCost()
     for limit_id, limit in limits.items():
         cost = costs.get(limit_id, 0.0)
         cost_limit_ratio = cost / limit if limit > 0 else 1.1

--- a/cads_processing_api_service/costing.py
+++ b/cads_processing_api_service/costing.py
@@ -26,7 +26,7 @@ from . import adaptors, costing, db_utils, models, utils
 def estimate_costs(
     process_id: str = fastapi.Path(...),
     execution_content: models.Execute = fastapi.Body(...),
-) -> models.Costing:
+) -> models.CostingInfo:
     request = execution_content.model_dump()
     table = cads_catalogue.database.Resource
     catalogue_sessionmaker = db_utils.get_catalogue_sessionmaker(
@@ -46,20 +46,35 @@ def estimate_costs(
 def compute_costing(
     request: dict[str, Any],
     adaptor_properties: dict[str, Any],
-) -> models.Costing:
+) -> models.CostingInfo:
+    """
+    Compute the costs of the request.
+
+    Parameters
+    ----------
+    request : dict[str, Any]
+        Request to be processed.
+    adaptor_properties : dict[str, Any]
+        Adaptor properties.
+
+    Returns
+    -------
+    models.CostingInfo
+        Costs of the request.
+    """
     adaptor: cads_adaptors.AbstractAdaptor = adaptors.instantiate_adaptor(
         adaptor_properties=adaptor_properties
     )
     costs: dict[str, float] = adaptor.estimate_costs(request=request)
     costing_config: dict[str, Any] = adaptor_properties["config"].get("costing", {})
-    max_costs: dict[str, Any] = costing_config.get("max_costs", {})
-    max_costs_exceeded = {}
-    for max_cost_id, max_cost_value in max_costs.items():
-        max_cost_value = float(max_cost_value)
-        if max_cost_id in costs.keys():
-            if costs[max_cost_id] > max_cost_value:
-                max_costs_exceeded[max_cost_id] = max_cost_value
-    costing_info = models.Costing(
-        costs=costs, max_costs=max_costs, max_costs_exceeded=max_costs_exceeded
+    limits: dict[str, Any] = costing_config.get("max_costs", {})
+    limits_exceeded = {}
+    for limit_id, limit in limits.items():
+        limit = float(limit)
+        if limit_id in costs.keys():
+            if costs[limit_id] > limit:
+                limits_exceeded[limit_id] = limit
+    costing_info = models.CostingInfo(
+        costs=costs, limits=limits, max_costs_exceeded=limits_exceeded
     )
     return costing_info

--- a/cads_processing_api_service/costing.py
+++ b/cads_processing_api_service/costing.py
@@ -23,10 +23,25 @@ import fastapi
 from . import adaptors, costing, db_utils, models, utils
 
 
-def estimate_costs(
+def estimate_cost(
     process_id: str = fastapi.Path(...),
     execution_content: models.Execute = fastapi.Body(...),
-) -> models.CostingInfo:
+) -> models.RequestCost:
+    """
+    Estimate the cost with the highest cost/limit ratio of the request.
+
+    Parameters
+    ----------
+    process_id : str
+        Process ID.
+    execution_content : models.Execute
+        Request content.
+
+    Returns
+    -------
+    models.RequestCost
+        Info on the cost with the highest cost/limit ratio.
+    """
     request = execution_content.model_dump()
     table = cads_catalogue.database.Resource
     catalogue_sessionmaker = db_utils.get_catalogue_sessionmaker(
@@ -40,7 +55,36 @@ def estimate_costs(
     costing_info = costing.compute_costing(
         request.get("inputs", {}), adaptor_properties
     )
-    return costing_info
+    cost = costing.compute_highest_cost_limit_ratio(costing_info)
+    return cost
+
+
+def compute_highest_cost_limit_ratio(
+    costing_info: models.CostingInfo,
+) -> models.RequestCost:
+    """
+    Compute the highest cost/limit ratio of the request.
+
+    Parameters
+    ----------
+    costing_info : models.CostingInfo
+        Costs of the request.
+
+    Returns
+    -------
+    models.RequestCost
+        Info on the cost with the highest cost/limit ratio.
+    """
+    costs = costing_info.costs
+    limits = costing_info.limits
+    highest_cost_limit_ratio = 0
+    for limit_id, limit in limits.items():
+        cost = costs.get(limit_id, 0.0)
+        cost_limit_ratio = cost / limit if limit > 0 else 1.1
+        if cost_limit_ratio > highest_cost_limit_ratio:
+            highest_cost_limit_ratio = cost_limit_ratio
+            highest_cost = models.RequestCost(cost=cost, limit=limit, id=limit_id)
+    return highest_cost
 
 
 def compute_costing(
@@ -68,13 +112,5 @@ def compute_costing(
     costs: dict[str, float] = adaptor.estimate_costs(request=request)
     costing_config: dict[str, Any] = adaptor_properties["config"].get("costing", {})
     limits: dict[str, Any] = costing_config.get("max_costs", {})
-    limits_exceeded = {}
-    for limit_id, limit in limits.items():
-        limit = float(limit)
-        if limit_id in costs.keys():
-            if costs[limit_id] > limit:
-                limits_exceeded[limit_id] = limit
-    costing_info = models.CostingInfo(
-        costs=costs, limits=limits, max_costs_exceeded=limits_exceeded
-    )
+    costing_info = models.CostingInfo(costs=costs, limits=limits)
     return costing_info

--- a/cads_processing_api_service/costing.py
+++ b/cads_processing_api_service/costing.py
@@ -77,7 +77,7 @@ def compute_highest_cost_limit_ratio(
     """
     costs = costing_info.costs
     limits = costing_info.limits
-    highest_cost_limit_ratio = 0
+    highest_cost_limit_ratio = 0.0
     highest_cost = models.RequestCost()
     for limit_id, limit in limits.items():
         cost = costs.get(limit_id, 0.0)

--- a/cads_processing_api_service/main.py
+++ b/cads_processing_api_service/main.py
@@ -69,7 +69,7 @@ app.router.add_api_route(
 )
 app.router.add_api_route(
     "/processes/{process_id}/costing",
-    costing.estimate_costs,
+    costing.estimate_cost,
     methods=["POST"],
 )
 app.router.add_api_route(

--- a/cads_processing_api_service/models.py
+++ b/cads_processing_api_service/models.py
@@ -70,7 +70,12 @@ class Exception(ogc_api_processes_fastapi.models.Exception):
 class CostingInfo(pydantic.BaseModel):
     costs: dict[str, float] | None = None
     limits: dict[str, float] | None = None
-    limits_exceeded: dict[str, float] | None = None
+
+
+class RequestCost(pydantic.BaseModel):
+    cost_id: str | None = None
+    cost: float = 0.0
+    cost_limit: float = 1.0
 
 
 class Execute(ogc_api_processes_fastapi.models.Execute):

--- a/cads_processing_api_service/models.py
+++ b/cads_processing_api_service/models.py
@@ -73,9 +73,9 @@ class CostingInfo(pydantic.BaseModel):
 
 
 class RequestCost(pydantic.BaseModel):
-    cost_id: str | None = None
+    id: str | None = None
     cost: float = 0.0
-    cost_limit: float = 1.0
+    limit: float = 1.0
 
 
 class Execute(ogc_api_processes_fastapi.models.Execute):

--- a/cads_processing_api_service/models.py
+++ b/cads_processing_api_service/models.py
@@ -67,10 +67,10 @@ class Exception(ogc_api_processes_fastapi.models.Exception):
     messages: list[tuple[str, str]] | None = None
 
 
-class Costing(pydantic.BaseModel):
+class CostingInfo(pydantic.BaseModel):
     costs: dict[str, float] | None = None
-    max_costs: dict[str, float] | None = None
-    max_costs_exceeded: dict[str, float] | None = None
+    limits: dict[str, float] | None = None
+    limits_exceeded: dict[str, float] | None = None
 
 
 class Execute(ogc_api_processes_fastapi.models.Execute):

--- a/cads_processing_api_service/models.py
+++ b/cads_processing_api_service/models.py
@@ -68,8 +68,8 @@ class Exception(ogc_api_processes_fastapi.models.Exception):
 
 
 class CostingInfo(pydantic.BaseModel):
-    costs: dict[str, float] | None = None
-    limits: dict[str, float] | None = None
+    costs: dict[str, float] = {}
+    limits: dict[str, float] = {}
 
 
 class RequestCost(pydantic.BaseModel):

--- a/tests/test_30_auth.py
+++ b/tests/test_30_auth.py
@@ -66,15 +66,16 @@ def test_verify_cost() -> None:
     with unittest.mock.patch(
         "cads_processing_api_service.costing.compute_costing"
     ) as mock_compute_costing:
-        mock_compute_costing.return_value = models.Costing(
-            costs={"cost_1": 1.0, "cost_2": 2.0},
-            max_costs_exceeded={},
+        mock_compute_costing.return_value = models.CostingInfo(
+            costs={"cost_id_1": 10.0, "cost_id_2": 10.0},
+            limits={"cost_id_1": 20.0, "cost_id_2": 20.0},
         )
-        auth.verify_cost({}, {})
+        costs = auth.verify_cost({}, {})
+        assert costs == {"cost_id_1": 10.0, "cost_id_2": 10.0}
 
-        mock_compute_costing.return_value = models.Costing(
-            costs={"cost_1": 1.0, "cost_2": 2.0},
-            max_costs_exceeded={"cost_1": 0},
+        mock_compute_costing.return_value = models.CostingInfo(
+            costs={"cost_id_1": 10.0, "cost_id_2": 10.0},
+            limits={"cost_id_1": 5.0, "cost_id_2": 20.0},
         )
         with pytest.raises(exceptions.PermissionDenied):
             auth.verify_cost({}, {})

--- a/tests/test_30_auth.py
+++ b/tests/test_30_auth.py
@@ -70,7 +70,7 @@ def test_verify_cost() -> None:
             costs={"cost_id_1": 10.0, "cost_id_2": 10.0},
             limits={"cost_id_1": 20.0, "cost_id_2": 20.0},
         )
-        costs = auth.verify_cost({}, {})
+        costs = auth.verify_cost({}, {}, "api")
         assert costs == {"cost_id_1": 10.0, "cost_id_2": 10.0}
 
         mock_compute_costing.return_value = models.CostingInfo(

--- a/tests/test_30_costing.py
+++ b/tests/test_30_costing.py
@@ -1,0 +1,61 @@
+# Copyright 2022, European Union.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# mypy: ignore-errors
+
+from cads_processing_api_service import costing, models
+
+
+def test_compute_highest_cost_limit_ratio() -> None:
+    costing_info = models.CostingInfo(
+        costs={
+            "cost_id_1": 10.0,
+            "cost_id_2": 10.0,
+        },
+        limits={
+            "cost_id_1": 20.0,
+            "cost_id_2": 20.0,
+        },
+    )
+    cost = costing.compute_highest_cost_limit_ratio(costing_info)
+    exp_cost = models.RequestCost(id="cost_id_1", cost=10.0, limit=20.0)
+    assert cost == exp_cost
+
+    costing_info = models.CostingInfo(
+        costs={
+            "cost_id_1": 10.0,
+            "cost_id_2": 30.0,
+        },
+        limits={
+            "cost_id_1": 20.0,
+            "cost_id_2": 20.0,
+        },
+    )
+    cost = costing.compute_highest_cost_limit_ratio(costing_info)
+    exp_cost = models.RequestCost(id="cost_id_2", cost=30.0, limit=20.0)
+    assert cost == exp_cost
+
+    costing_info = models.CostingInfo(
+        costs={
+            "cost_id_1": 10.0,
+            "cost_id_2": 10.0,
+        },
+        limits={
+            "cost_id_1": 20.0,
+            "cost_id_2": 0.0,
+        },
+    )
+    cost = costing.compute_highest_cost_limit_ratio(costing_info)
+    exp_cost = models.RequestCost(id="cost_id_2", cost=10.0, limit=0.0)
+    assert cost == exp_cost


### PR DESCRIPTION
This PR refactor `/costing` endpoint's response, in order to ease logic on the front-end side.

The *new* response will looks like this:
```
{
    "id": "example_cost_id",
    "cost": 10,
    "limit": 20,
}
```
and it will only contain **one set** of `(id, cost, limit)` to be used to decide wether to block submission, what to write on the eventual warning message and how the cost bar should look.

**Related to**
- https://jira.ecmwf.int/browse/COPDS-2051