### PR TITLE
add cost_bar_steps to /costing response

### DIFF
--- a/cads_processing_api_service/costing.py
+++ b/cads_processing_api_service/costing.py
@@ -65,6 +65,8 @@ def estimate_cost(
         request.get("inputs", {}), adaptor_properties, request_origin
     )
     cost = costing.compute_highest_cost_limit_ratio(costing_info)
+    if costing_info.cost_bar_steps:
+        cost.cost_bar_steps = costing_info.cost_bar_steps
     return cost
 
 
@@ -128,5 +130,8 @@ def compute_costing(
     )
     costing_config: dict[str, Any] = adaptor_properties["config"].get("costing", {})
     limits: dict[str, Any] = costing_config.get("max_costs", {})
-    costing_info = models.CostingInfo(costs=costs, limits=limits)
+    cost_bar_steps = costing_config.get("cost_bar_steps", None)
+    costing_info = models.CostingInfo(
+        costs=costs, limits=limits, cost_bar_steps=cost_bar_steps
+    )
     return costing_info

--- a/cads_processing_api_service/models.py
+++ b/cads_processing_api_service/models.py
@@ -70,12 +70,14 @@ class Exception(ogc_api_processes_fastapi.models.Exception):
 class CostingInfo(pydantic.BaseModel):
     costs: dict[str, float] = {}
     limits: dict[str, float] = {}
+    cost_bar_steps: list[int] | None = None
 
 
 class RequestCost(pydantic.BaseModel):
     id: str | None = None
     cost: float = 0.0
     limit: float = 1.0
+    cost_bar_steps: list[int] | None = None
 
 
 class Execute(ogc_api_processes_fastapi.models.Execute):


### PR DESCRIPTION
This PR adds the `cost_bar_steps` field to the `/costing` endpoint's response.
It's either a list of integers, indicating the percentage at which the bar should change color, or null, in which case the bar should always have the same color.