### PR TITLE
Reduce users cache TTL

### DIFF
--- a/cads_processing_api_service/config.py
+++ b/cads_processing_api_service/config.py
@@ -75,7 +75,7 @@ class Settings(pydantic_settings.BaseSettings):
     public_cache_control: str = "public, max-age=60"
 
     cache_users_maxsize: int = 2000
-    cache_users_ttl: int = 600
+    cache_users_ttl: int = 60
     cache_resources_maxsize: int = 1000
     cache_resources_ttl: int = 10
 


### PR DESCRIPTION
This PR reduce default users cache TTL. This is motivated by the necessity to reduce time blocked users can continue interacting with the system.