### PR TITLE
Refactor config handling

### DIFF
--- a/cads_processing_api_service/auth.py
+++ b/cads_processing_api_service/auth.py
@@ -24,6 +24,8 @@ import requests
 
 from . import config, costing, exceptions, models
 
+SETTINGS = config.settings
+
 VERIFICATION_ENDPOINT = {
     "PRIVATE-TOKEN": "/account/verification/pat",
     "Authorization": "/account/verification/oidc",
@@ -75,8 +77,8 @@ def get_auth_header(
 
 @cachetools.cached(
     cache=cachetools.TTLCache(
-        maxsize=config.ensure_settings().cache_users_maxsize,
-        ttl=config.ensure_settings().cache_users_ttl,
+        maxsize=SETTINGS.cache_users_maxsize,
+        ttl=SETTINGS.cache_users_ttl,
     ),
 )
 def authenticate_user(
@@ -104,13 +106,12 @@ def authenticate_user(
         registered/authorized user.
     """
     verification_endpoint = VERIFICATION_ENDPOINT[auth_header[0]]
-    settings = config.ensure_settings()
-    request_url = urllib.parse.urljoin(settings.profiles_api_url, verification_endpoint)
+    request_url = urllib.parse.urljoin(SETTINGS.profiles_api_url, verification_endpoint)
     response = requests.post(
         request_url,
         headers={
             auth_header[0]: auth_header[1],
-            config.PORTAL_HEADER_NAME: portal_header,
+            SETTINGS.portal_header_name: portal_header,
         },
     )
     if response.status_code in (
@@ -165,8 +166,7 @@ def get_accepted_licences(auth_header: tuple[str, str]) -> set[tuple[str, int]]:
     set[tuple[str, int]]
         Accepted licences.
     """
-    settings = config.ensure_settings()
-    request_url = urllib.parse.urljoin(settings.profiles_api_url, "account/licences")
+    request_url = urllib.parse.urljoin(SETTINGS.profiles_api_url, "account/licences")
     response = requests.get(request_url, headers={auth_header[0]: auth_header[1]})
     if response.status_code in (
         fastapi.status.HTTP_401_UNAUTHORIZED,
@@ -219,10 +219,8 @@ def verify_licences(
         required_licences = set(required_licences)
     missing_licences = required_licences - accepted_licences
     if not len(missing_licences) == 0:
-        missing_licences_message_template = (
-            config.ensure_settings().missing_licences_message
-        )
-        dataset_licences_url_template = config.ensure_settings().dataset_licences_url
+        missing_licences_message_template = SETTINGS.missing_licences_message
+        dataset_licences_url_template = SETTINGS.dataset_licences_url
         parsed_api_request_url = urllib.parse.urlparse(api_request_url)
         base_url = f"{parsed_api_request_url.scheme}://{parsed_api_request_url.netloc}"
         dataset_licences_url = dataset_licences_url_template.format(

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -192,7 +192,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         execution_content: models.Execute = fastapi.Body(...),
         auth_header: tuple[str, str] = fastapi.Depends(auth.get_auth_header),
         portal_header: str | None = fastapi.Header(
-            None, alias=config.PORTAL_HEADER_NAME
+            None, alias=SETTINGS.portal_header_name
         ),
     ) -> models.StatusInfo:
         """Implement OGC API - Processes `POST /processes/{process_id}/execution` endpoint.
@@ -323,7 +323,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         back: bool | None = fastapi.Query(None, include_in_schema=False),
         auth_header: tuple[str, str] = fastapi.Depends(auth.get_auth_header),
         portal_header: str | None = fastapi.Header(
-            None, alias=config.PORTAL_HEADER_NAME
+            None, alias=SETTINGS.portal_header_name
         ),
     ) -> models.JobList:
         """Implement OGC API - Processes `GET /jobs` endpoint.
@@ -439,7 +439,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         job_id: str = fastapi.Path(...),
         auth_header: tuple[str, str] = fastapi.Depends(auth.get_auth_header),
         portal_header: str | None = fastapi.Header(
-            None, alias=config.PORTAL_HEADER_NAME
+            None, alias=SETTINGS.portal_header_name
         ),
         qos: bool = fastapi.Query(False),
         request: bool = fastapi.Query(False),
@@ -562,7 +562,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         job_id: str = fastapi.Path(...),
         auth_header: tuple[str, str] = fastapi.Depends(auth.get_auth_header),
         portal_header: str | None = fastapi.Header(
-            None, alias=config.PORTAL_HEADER_NAME
+            None, alias=SETTINGS.portal_header_name
         ),
     ) -> ogc_api_processes_fastapi.models.Results:
         """Implement OGC API - Processes `GET /jobs/{job_id}/results` endpoint.
@@ -615,7 +615,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         job_id: str = fastapi.Path(...),
         auth_header: tuple[str, str] = fastapi.Depends(auth.get_auth_header),
         portal_header: str | None = fastapi.Header(
-            None, alias=config.PORTAL_HEADER_NAME
+            None, alias=SETTINGS.portal_header_name
         ),
     ) -> ogc_api_processes_fastapi.models.StatusInfo:
         """Implement OGC API - Processes `DELETE /jobs/{job_id}` endpoint.

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -51,6 +51,8 @@ from . import (
 )
 from .metrics import handle_download_metrics
 
+SETTINGS = config.settings
+
 logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
 
 
@@ -179,9 +181,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
             ),
         }
 
-        response.headers["cache-control"] = (
-            config.ensure_settings().public_cache_control
-        )
+        response.headers["cache-control"] = SETTINGS.public_cache_control
 
         return process_description
 
@@ -254,7 +254,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
             )
             job_message = None
         else:
-            job_message = config.ensure_settings().anonymous_licences_message.format(
+            job_message = SETTINGS.anonymous_licences_message.format(
                 licences="; ".join(
                     [
                         f"{licence[0]} (rev: {licence[1]})"
@@ -295,7 +295,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
             message = models.DatasetMessage(
                 date=datetime.datetime.now(),
                 severity="WARNING",
-                content=config.ensure_settings().deprecation_warning_message,
+                content=SETTINGS.deprecation_warning_message,
             )
             dataset_messages.append(message)
         status_info = utils.make_status_info(
@@ -406,7 +406,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
                             session=catalogue_session,
                         )
                     except ogc_api_processes_fastapi.exceptions.NoSuchProcess:
-                        dataset_title = config.ensure_settings().missing_dataset_title
+                        dataset_title = SETTINGS.missing_dataset_title
                 results = utils.parse_results_from_broker_db(
                     job, session=compute_session
                 )

--- a/cads_processing_api_service/config.py
+++ b/cads_processing_api_service/config.py
@@ -131,7 +131,7 @@ def load_download_nodes(download_nodes_file: pathlib.Path) -> list[str]:
     return download_nodes
 
 
-class DownloadNodesSettings(pydantic.BaseModel):
+class DownloadNodesSettings(pydantic_settings.BaseSettings):
     """Settings for download nodes."""
 
     download_nodes_file: Annotated[

--- a/cads_processing_api_service/config.py
+++ b/cads_processing_api_service/config.py
@@ -102,20 +102,23 @@ class Settings(pydantic_settings.BaseSettings):
 settings = Settings()
 
 
-def validate_download_nodes_file(download_nodes_file: pathlib.Path) -> pathlib.Path:
-    if not download_nodes_file.exists():
-        raise FileNotFoundError(f"Download nodes file not found: {download_nodes_file}")
+def validate_download_nodes_file(download_nodes_file: str) -> pathlib.Path:
+    download_nodes_file_path = pathlib.Path(download_nodes_file)
+    if not download_nodes_file_path.exists():
+        raise FileNotFoundError(
+            f"Download nodes file not found: {download_nodes_file_path}"
+        )
     try:
-        with open(download_nodes_file, "r") as file:
+        with open(download_nodes_file_path, "r") as file:
             lines = file.readlines()
             line_count = len(lines)
             if line_count == 0:
                 raise ValueError("Download nodes file is empty")
     except Exception as e:
         raise ValueError(
-            f"Failed to read download nodes file: {download_nodes_file}"
+            f"Failed to read download nodes file: {download_nodes_file_path}"
         ) from e
-    return download_nodes_file
+    return download_nodes_file_path
 
 
 @functools.lru_cache
@@ -132,7 +135,7 @@ class DownloadNodesSettings(pydantic.BaseModel):
     """Settings for download nodes."""
 
     download_nodes_file: Annotated[
-        pathlib.Path, pydantic.AfterValidator(validate_download_nodes_file)
+        str, pydantic.AfterValidator(validate_download_nodes_file)
     ] = "/etc/retrieve-api/download-nodes.config"
 
     @property

--- a/cads_processing_api_service/config.py
+++ b/cads_processing_api_service/config.py
@@ -63,7 +63,7 @@ MISSING_LICENCES_MESSAGE = (
 )
 
 
-def load_downlaod_nodes(v: list[str], info: pydantic.ValidationInfo) -> list[str]:
+def load_download_nodes(v: list[str], info: pydantic.ValidationInfo) -> list[str]:
     v = []
     file_path = info.data.get("download_nodes_file")
     if file_path:
@@ -118,7 +118,7 @@ class Settings(pydantic_settings.BaseSettings):
 
     download_nodes_file: str = "/etc/retrieve-api/download-nodes.config"
     download_nodes: Annotated[
-        list[str], pydantic.BeforeValidator(load_downlaod_nodes)
+        list[str], pydantic.BeforeValidator(load_download_nodes)
     ] = []
 
     @property

--- a/cads_processing_api_service/config.py
+++ b/cads_processing_api_service/config.py
@@ -17,6 +17,7 @@ Options are based on pydantic.BaseSettings, so they automatically get values fro
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import os
 import random
 
@@ -61,6 +62,7 @@ MISSING_LICENCES_MESSAGE = (
 )
 
 
+@functools.lru_cache
 def load_download_nodes(download_nodes_file: str) -> list[str]:
     download_nodes = []
     try:

--- a/cads_processing_api_service/config.py
+++ b/cads_processing_api_service/config.py
@@ -59,14 +59,12 @@ MISSING_LICENCES_MESSAGE = (
 )
 
 
-general_settings = None
-
-
 class Settings(pydantic_settings.BaseSettings):
     """General settings."""
 
     profiles_service: str = "profiles-api"
     profiles_api_service_port: int = 8000
+    portal_header_name: str = "X-CADS-PORTAL"
 
     allow_cors: bool = True
 
@@ -105,26 +103,4 @@ class Settings(pydantic_settings.BaseSettings):
         return random.choice(download_nodes)
 
 
-def ensure_settings(
-    settings: Settings | None = None,
-) -> Settings:
-    """If `settings` is None, create a new Settings object.
-
-    Parameters
-    ----------
-    settings: an optional Settings object to be set as general settings.
-
-    Returns
-    -------
-    Settings:
-        General settings.
-    """
-    global general_settings
-    if settings and isinstance(settings, pydantic_settings.BaseSettings):
-        general_settings = settings
-    else:
-        general_settings = Settings()
-    return general_settings
-
-
-PORTAL_HEADER_NAME = "X-CADS-PORTAL"
+settings = Settings()

--- a/cads_processing_api_service/main.py
+++ b/cads_processing_api_service/main.py
@@ -36,6 +36,8 @@ from . import (
     translators,
 )
 
+SETTINGS = config.settings
+
 
 def add_user_request_flag(
     logger: logging.Logger, method_name: str, event_dict: MutableMapping[str, Any]
@@ -96,7 +98,7 @@ async def initialize_logger(
     return response
 
 
-if config.ensure_settings().allow_cors:
+if SETTINGS.allow_cors:
     app.add_middleware(
         fastapi.middleware.cors.CORSMiddleware,
         allow_origins=["*"],

--- a/cads_processing_api_service/middlewares.py
+++ b/cads_processing_api_service/middlewares.py
@@ -20,6 +20,7 @@ import starlette_exporter
 
 from . import config
 
+SETTINGS = config.settings
 CACHEABLE_HTTP_METHODS = ["GET", "HEAD"]
 
 
@@ -39,11 +40,10 @@ class CacheControlMiddleware(starlette.middleware.base.BaseHTTPMiddleware):
             "cache-control" not in response.headers
             and request.method in CACHEABLE_HTTP_METHODS
         ):
-            settings = config.ensure_settings()
-            if settings.default_cache_control:
-                response.headers["cache-control"] = settings.default_cache_control
-            if settings.default_vary:
-                response.headers["vary"] = settings.default_vary
+            if SETTINGS.default_cache_control:
+                response.headers["cache-control"] = SETTINGS.default_cache_control
+            if SETTINGS.default_vary:
+                response.headers["vary"] = SETTINGS.default_vary
         return response
 
 

--- a/cads_processing_api_service/translators.py
+++ b/cads_processing_api_service/translators.py
@@ -21,6 +21,8 @@ import structlog
 
 from . import config
 
+SETTINGS = config.settings
+
 logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
 
 
@@ -274,9 +276,7 @@ def format_request_value(
         if key is None:
             formatted_request_value = format_list(request_value)
         else:
-            api_request_max_list_length = (
-                config.ensure_settings().api_request_max_list_length
-            )
+            api_request_max_list_length = SETTINGS.api_request_max_list_length
             max_items_per_line = api_request_max_list_length.get(key, 1)
             formatted_request_value = format_list(request_value, max_items_per_line)
     elif isinstance(request_value, str):
@@ -343,6 +343,6 @@ def get_api_request(
     dict[str, str]
         CDS API request.
     """
-    api_request_template = config.ensure_settings().api_request_template
+    api_request_template = SETTINGS.api_request_template
     api_request = format_api_request(api_request_template, process_id, request)
     return {"api_request": api_request}

--- a/cads_processing_api_service/utils.py
+++ b/cads_processing_api_service/utils.py
@@ -38,6 +38,8 @@ import structlog
 
 from . import config, exceptions, models
 
+SETTINGS = config.settings
+
 logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
 
 
@@ -53,8 +55,8 @@ class JobSortCriterion(str, enum.Enum):
 
 @cachetools.cached(
     cache=cachetools.TTLCache(
-        maxsize=config.ensure_settings().cache_resources_maxsize,
-        ttl=config.ensure_settings().cache_resources_ttl,
+        maxsize=SETTINGS.cache_resources_maxsize,
+        ttl=SETTINGS.cache_resources_ttl,
     ),
     lock=threading.Lock(),
     key=lambda resource_id,
@@ -113,8 +115,8 @@ def lookup_resource_by_id(
 
 @cachetools.cached(
     cache=cachetools.TTLCache(
-        maxsize=config.ensure_settings().cache_resources_maxsize,
-        ttl=config.ensure_settings().cache_resources_ttl,
+        maxsize=SETTINGS.cache_resources_maxsize,
+        ttl=SETTINGS.cache_resources_ttl,
     ),
     key=lambda resource_id, table, properties, session: cachetools.keys.hashkey(
         resource_id, table, properties
@@ -472,7 +474,7 @@ def get_job_from_broker_db(
 
 def update_results_href(local_path: str, download_node: str | None = None) -> str:
     if download_node is None:
-        download_node = config.ensure_settings().download_node
+        download_node = SETTINGS.download_node
     file_path = local_path.split("://", 1)[-1]
     results_href = urllib.parse.urljoin(download_node, file_path)
     return results_href

--- a/cads_processing_api_service/utils.py
+++ b/cads_processing_api_service/utils.py
@@ -472,9 +472,7 @@ def get_job_from_broker_db(
     return job
 
 
-def update_results_href(local_path: str, download_node: str | None = None) -> str:
-    if download_node is None:
-        download_node = SETTINGS.download_node
+def update_results_href(local_path: str, download_node: str) -> str:
     file_path = local_path.split("://", 1)[-1]
     results_href = urllib.parse.urljoin(download_node, file_path)
     return results_href
@@ -511,7 +509,9 @@ def get_results_from_job(
             raise exceptions.JobResultsExpired(
                 detail=f"results of job {job_id} expired"
             )
-        asset_value["href"] = update_results_href(asset_value["file:local_path"])
+        asset_value["href"] = update_results_href(
+            asset_value["file:local_path"], SETTINGS.download_node
+        )
         results = {"asset": {"value": asset_value}}
     elif job_status == "failed":
         error_messages = get_job_events(

--- a/cads_processing_api_service/utils.py
+++ b/cads_processing_api_service/utils.py
@@ -510,7 +510,7 @@ def get_results_from_job(
                 detail=f"results of job {job_id} expired"
             )
         asset_value["href"] = update_results_href(
-            asset_value["file:local_path"], SETTINGS.download_node
+            asset_value["file:local_path"], config.DownloadNodesSettings().download_node
         )
         results = {"asset": {"value": asset_value}}
     elif job_status == "failed":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,17 +13,8 @@
 # limitations under the License.
 
 import os
-import pathlib
-import tempfile
 
 import pytest
-
-
-def pytest_sessionstart(session):
-    temp_dir = pathlib.Path(tempfile.mkdtemp())
-    download_nodes_file = temp_dir / "test-download-nodes.config"
-    download_nodes_file.write_text("http://download_node_1/")
-    os.environ["DOWNLOAD_NODES_FILE"] = str(download_nodes_file)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# mypy: ignore-errors
 import os
 
 import pytest
@@ -29,3 +30,13 @@ def dev_env_prof_api_url() -> str:
     api_root_url = os.environ.get("CADS_API_ROOT_URL", "http://localhost:8080/api")
     prof_api_url = f"{api_root_url}/profiles/v1/"
     return prof_api_url
+
+
+@pytest.fixture(scope="session")
+def prepare_env_for_download_nodes(tmp_path_factory) -> None:
+    temp_dir = tmp_path_factory.mktemp("data")
+    temp_file_path = temp_dir / "test-download-nodes.config"
+    # Create and write to the file
+    with open(temp_file_path, "w") as f:
+        f.write("http://test_node")
+    os.environ["DOWNLOAD_NODES_FILE"] = str(temp_file_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,17 @@
 # limitations under the License.
 
 import os
+import pathlib
+import tempfile
 
 import pytest
+
+
+def pytest_sessionstart(session):
+    temp_dir = pathlib.Path(tempfile.mkdtemp())
+    download_nodes_file = temp_dir / "test-download-nodes.config"
+    download_nodes_file.write_text("http://download_node_1/")
+    os.environ["DOWNLOAD_NODES_FILE"] = str(download_nodes_file)
 
 
 @pytest.fixture

--- a/tests/test_10_config.py
+++ b/tests/test_10_config.py
@@ -16,6 +16,8 @@
 
 import pathlib
 
+import pytest
+
 from cads_processing_api_service import config
 
 
@@ -24,10 +26,19 @@ def test_load_download_nodes(tmp_path: pathlib.Path) -> None:
     download_nodes_file.write_text(
         "http://download_node_1/\n\nhttp://download_node_2/\nhttp://download_node_3/"
     )
-    downolad_nodes = config.load_download_nodes(download_nodes_file)
+    download_nodes = config.load_download_nodes(download_nodes_file)
     exp_download_nodes = [
         "http://download_node_1/",
         "http://download_node_2/",
         "http://download_node_3/",
     ]
-    assert downolad_nodes == exp_download_nodes
+    assert download_nodes == exp_download_nodes
+
+    not_existing_download_nodes_file = tmp_path / "not-existing-download-nodes.config"
+    with pytest.raises(FileNotFoundError):
+        download_nodes = config.load_download_nodes(not_existing_download_nodes_file)
+
+    empty_download_nodes_file = tmp_path / "empty-download-nodes.config"
+    empty_download_nodes_file.write_text("")
+    with pytest.raises(ValueError):
+        download_nodes = config.load_download_nodes(empty_download_nodes_file)

--- a/tests/test_10_config.py
+++ b/tests/test_10_config.py
@@ -21,6 +21,17 @@ import pytest
 from cads_processing_api_service import config
 
 
+def test_validate_download_nodes_file(tmp_path: pathlib.Path) -> None:
+    not_existing_download_nodes_file = tmp_path / "not-existing-download-nodes.config"
+    with pytest.raises(FileNotFoundError):
+        _ = config.validate_download_nodes_file(not_existing_download_nodes_file)
+
+    empty_download_nodes_file = tmp_path / "empty-download-nodes.config"
+    empty_download_nodes_file.write_text("")
+    with pytest.raises(ValueError):
+        _ = config.validate_download_nodes_file(empty_download_nodes_file)
+
+
 def test_load_download_nodes(tmp_path: pathlib.Path) -> None:
     download_nodes_file = tmp_path / "download-nodes.config"
     download_nodes_file.write_text(
@@ -33,12 +44,3 @@ def test_load_download_nodes(tmp_path: pathlib.Path) -> None:
         "http://download_node_3/",
     ]
     assert download_nodes == exp_download_nodes
-
-    not_existing_download_nodes_file = tmp_path / "not-existing-download-nodes.config"
-    with pytest.raises(FileNotFoundError):
-        download_nodes = config.load_download_nodes(not_existing_download_nodes_file)
-
-    empty_download_nodes_file = tmp_path / "empty-download-nodes.config"
-    empty_download_nodes_file.write_text("")
-    with pytest.raises(ValueError):
-        download_nodes = config.load_download_nodes(empty_download_nodes_file)

--- a/tests/test_10_config.py
+++ b/tests/test_10_config.py
@@ -1,0 +1,33 @@
+# Copyright 2022, European Union.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# mypy: ignore-errors
+
+import pathlib
+
+from cads_processing_api_service import config
+
+
+def test_load_download_nodes(tmp_path: pathlib.Path) -> None:
+    download_nodes_file = tmp_path / "download-nodes.config"
+    download_nodes_file.write_text(
+        "http://download_node_1/\n\nhttp://download_node_2/\nhttp://download_node_3/"
+    )
+    downolad_nodes = config.load_download_nodes(download_nodes_file)
+    exp_download_nodes = [
+        "http://download_node_1/",
+        "http://download_node_2/",
+        "http://download_node_3/",
+    ]
+    assert downolad_nodes == exp_download_nodes

--- a/tests/test_30_utils.py
+++ b/tests/test_30_utils.py
@@ -256,7 +256,7 @@ def test_update_results_href() -> None:
     assert updated_href == exp_updated_href
 
 
-def test_get_results_from_job() -> None:
+def test_get_results_from_job(prepare_env_for_download_nodes) -> None:
     mock_session = unittest.mock.Mock(spec=sqlalchemy.orm.Session)
     job = cads_broker.SystemRequest(
         **{
@@ -264,25 +264,23 @@ def test_get_results_from_job() -> None:
             "request_uid": "1234",
             "cache_entry": cacholote.database.CacheEntry(
                 result={
-                    "args": [{"key": "value", "file:local_path": "test_local_path"}]
+                    "args": [
+                        {
+                            "key": "value",
+                            "file:local_path": "protocol://test_local_path",
+                        }
+                    ]
                 }
             ),
         }
     )
-    with unittest.mock.patch(
-        "cads_processing_api_service.config.load_download_nodes"
-    ) as mock_download_nodes, unittest.mock.patch(
-        "cads_processing_api_service.utils.update_results_href",
-    ) as mock_update_results_href:
-        mock_download_nodes.return_value = ["http://download_node/"]
-        mock_update_results_href.return_value = "test_href"
-        results = utils.get_results_from_job(job, session=mock_session)
+    results = utils.get_results_from_job(job, session=mock_session)
     exp_results = {
         "asset": {
             "value": {
                 "key": "value",
-                "file:local_path": "test_local_path",
-                "href": "test_href",
+                "file:local_path": "protocol://test_local_path",
+                "href": "http://test_node/test_local_path",
             }
         }
     }

--- a/tests/test_30_utils.py
+++ b/tests/test_30_utils.py
@@ -14,7 +14,6 @@
 
 # mypy: ignore-errors
 import datetime
-import pathlib
 import unittest.mock
 import uuid
 from typing import Any
@@ -255,19 +254,6 @@ def test_update_results_href() -> None:
     updated_href = utils.update_results_href(local_path, download_node)
     exp_updated_href = "http://download_node/results/1234"
     assert updated_href == exp_updated_href
-
-
-def test_update_results_href_from_config(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
-) -> None:
-    config_path = tmp_path / "download-nodes.config"
-    config_path.write_text("\n\nhttp://download_node/\n\n$DOWNLOAD_NODE\n\n")
-    monkeypatch.setenv("DOWNLOAD_NODE", "http://download_node/")
-    monkeypatch.setenv("DOWNLOAD_NODES_CONFIG", str(config_path))
-
-    local_path = "protocol://results/1234"
-    updated_href = utils.update_results_href(local_path)
-    assert updated_href == "http://download_node/results/1234"
 
 
 def test_get_results_from_job() -> None:

--- a/tests/test_30_utils.py
+++ b/tests/test_30_utils.py
@@ -270,8 +270,11 @@ def test_get_results_from_job() -> None:
         }
     )
     with unittest.mock.patch(
-        "cads_processing_api_service.utils.update_results_href"
+        "cads_processing_api_service.config.load_download_nodes"
+    ) as mock_download_nodes, unittest.mock.patch(
+        "cads_processing_api_service.utils.update_results_href",
     ) as mock_update_results_href:
+        mock_download_nodes.return_value = ["http://download_node/"]
         mock_update_results_href.return_value = "test_href"
         results = utils.get_results_from_job(job, session=mock_session)
     exp_results = {


### PR DESCRIPTION
This PR refactors config handling, removing reliance on the `ensure_settings()` function. 

`Settings()` is instantiated in the `config.py` module at import, and then accessed by all the modules requiring it. All fields contained in it have a default, so there's no risk of `ValidationError` at import. Also, there's no need to re-instantiate the class at each use, since environment variables in pods can only be changed via a restart of the pod.

A class dedicated to download nodes settings, `DownloadNodesSettings()` is introduced: its fields are required and an `AfterValidation` is applied, so this settings are *not* instantiated at module import but only inside functions that required them.