### PR TITLE
Implement rate limiting for authenticated routes

### DIFF
--- a/cads_processing_api_service/auth.py
+++ b/cads_processing_api_service/auth.py
@@ -153,9 +153,11 @@ def get_auth_info(
     """
     auth_header = get_auth_header(pat, jwt)
     user_uid, user_role = authenticate_user(auth_header, portal_header)
+    request_origin = REQUEST_ORIGIN[auth_header[0]]
     auth_info = models.AuthInfo(
         user_uid=user_uid,
         user_role=user_role,
+        request_origin=request_origin,
         auth_header=auth_header,
         portal_header=portal_header,
     )

--- a/cads_processing_api_service/auth.py
+++ b/cads_processing_api_service/auth.py
@@ -154,7 +154,10 @@ def get_auth_info(
     auth_header = get_auth_header(pat, jwt)
     user_uid, user_role = authenticate_user(auth_header, portal_header)
     auth_info = models.AuthInfo(
-        user_uid=user_uid, user_role=user_role, auth_header=auth_header
+        user_uid=user_uid,
+        user_role=user_role,
+        auth_header=auth_header,
+        portal_header=portal_header,
     )
     return auth_info
 

--- a/cads_processing_api_service/auth.py
+++ b/cads_processing_api_service/auth.py
@@ -75,7 +75,7 @@ def get_auth_header(pat: str | None = None, jwt: str | None = None) -> tuple[str
 )
 def authenticate_user(
     auth_header: tuple[str, str], portal_header: str | None = None
-) -> tuple[str | None, str | None]:
+) -> tuple[str, str | None]:
     """Verify user authentication.
 
     Verify if the provided authentication header corresponds to a registered user.
@@ -88,7 +88,7 @@ def authenticate_user(
 
     Returns
     -------
-    tuple[str, str] | None
+    tuple[str, str | None]
         User identifier and role.
 
     Raises
@@ -116,8 +116,8 @@ def authenticate_user(
             detail="operation not allowed",
         )
     response.raise_for_status()
-    user: dict[str, Any] = response.json()
-    user_uid: str | None = user.get("sub", None)
+    user: dict[str, str] = response.json()
+    user_uid: str = user["sub"]
     user_role: str | None = user.get("role", None)
     return user_uid, user_role
 

--- a/cads_processing_api_service/auth.py
+++ b/cads_processing_api_service/auth.py
@@ -129,7 +129,7 @@ def get_auth_info(
     jwt: str | None = fastapi.Header(
         None, description="JSON Web Token", alias="Authorization"
     ),
-    portal_header: str | None = fastapi.Header(None, alias=config.PORTAL_HEADER_NAME),
+    portal_header: str | None = fastapi.Header(None, alias=SETTINGS.portal_header_name),
 ) -> models.AuthInfo | None:
     """Get authentication information from the incoming HTTP request.
 

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -213,7 +213,10 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         models.StatusInfo
             Submitted job's status information.
         """
-        _ = limits.check_rate_limit("post_process_execution", auth_info)
+        _ = limits.check_rate_limits(
+            SETTINGS.rate_limits.process_execution.post,
+            auth_info,
+        )
         structlog.contextvars.bind_contextvars(user_uid=auth_info.user_uid)
         request_body = execution_content.model_dump()
         catalogue_sessionmaker = db_utils.get_catalogue_sessionmaker(

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -354,8 +354,9 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         models.JobList
             List of jobs status information.
         """
-        user_uid, _ = auth.authenticate_user(
-            auth_info.auth_header, auth_info.portal_header
+        _ = limits.check_rate_limits(
+            SETTINGS.rate_limits.jobs.get,
+            auth_info,
         )
         portals = (
             [p.strip() for p in auth_info.portal_header.split(",")]
@@ -365,7 +366,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         job_filters = {
             "process_id": processID,
             "status": status,
-            "user_uid": [user_uid],
+            "user_uid": [auth_info.user_uid],
             "portal": portals,
         }
         sort_key, sort_dir = utils.parse_sortby(sortby.name)
@@ -472,6 +473,10 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         models.StatusInfo
             Job status information.
         """
+        _ = limits.check_rate_limits(
+            SETTINGS.rate_limits.job.get,
+            auth_info,
+        )
         portals = (
             [p.strip() for p in auth_info.portal_header.split(",")]
             if auth_info.portal_header
@@ -577,6 +582,10 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         ogc_api_processes_fastapi.models.Results
             Job results.
         """
+        _ = limits.check_rate_limits(
+            SETTINGS.rate_limits.job_results.get,
+            auth_info,
+        )
         structlog.contextvars.bind_contextvars(
             job_id=job_id, user_uid=auth_info.user_uid
         )
@@ -627,6 +636,10 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         ogc_api_processes_fastapi.models.StatusInfo
             Job status information
         """
+        _ = limits.check_rate_limits(
+            SETTINGS.rate_limits.job.delete,
+            auth_info,
+        )
         structlog.contextvars.bind_contextvars(
             job_id=job_id, user_id=auth_info.user_uid
         )

--- a/cads_processing_api_service/config.py
+++ b/cads_processing_api_service/config.py
@@ -189,9 +189,7 @@ class Settings(pydantic_settings.BaseSettings):
 
     @pydantic.model_validator(mode="after")  # type: ignore
     def load_rate_limits(self) -> pydantic_settings.BaseSettings:
-        self.rate_limits: RateLimitsConfig = load_rate_limits(
-            pathlib.Path(self.rate_limits_file)
-        )
+        self.rate_limits: RateLimitsConfig = load_rate_limits(self.rate_limits_file)
         return self
 
 
@@ -207,17 +205,10 @@ def validate_download_nodes_file(download_nodes_file: str) -> pathlib.Path:
 @functools.lru_cache
 def load_download_nodes(download_nodes_file: pathlib.Path) -> list[str]:
     download_nodes = []
-    if not download_nodes_file.exists():
-        raise FileNotFoundError(f"Download nodes file not found: {download_nodes_file}")
-    try:
-        with open(download_nodes_file, "r") as file:
-            for line in file:
-                if download_node := os.path.expandvars(line.rstrip("\n")):
-                    download_nodes.append(download_node)
-    except Exception as e:
-        raise ValueError(
-            f"Failed to read download nodes file: {download_nodes_file}"
-        ) from e
+    with open(download_nodes_file, "r") as file:
+        for line in file:
+            if download_node := os.path.expandvars(line.rstrip("\n")):
+                download_nodes.append(download_node)
     if not download_nodes:
         raise ValueError(
             f"No download nodes found in download nodes file: {download_nodes_file}"

--- a/cads_processing_api_service/config.py
+++ b/cads_processing_api_service/config.py
@@ -152,15 +152,6 @@ def load_rate_limits(rate_limits_file: str) -> RateLimitsConfig:
     return rate_limits
 
 
-def validate_rate_limits_file(rate_limits_file: str) -> pathlib.Path:
-    rate_limits_file_path = pathlib.Path(rate_limits_file)
-    if not rate_limits_file_path.exists():
-        logger.warning("Rate limits file not found", rate_limits_file=rate_limits_file)
-        return rate_limits_file_path
-    _ = load_rate_limits(rate_limits_file_path)
-    return rate_limits_file_path
-
-
 class Settings(pydantic_settings.BaseSettings):
     """General API settings."""
 

--- a/cads_processing_api_service/config.py
+++ b/cads_processing_api_service/config.py
@@ -96,13 +96,13 @@ class Settings(pydantic_settings.BaseSettings):
         "{base_url}/datasets/{process_id}?tab=download#manage-licences"
     )
 
-    rate_limits_config: str = "/etc/retrieve-api/rate-limits.yaml"
+    rate_limits_file: str = "/etc/retrieve-api/rate-limits.yaml"
 
     @property
-    def rate_limits(self) -> dict:
-        rate_limits = {"post_process_execution": {"api": ["2/minute"]}}
-        if os.path.exists(self.rate_limits_config):
-            with open(self.rate_limits_config) as fp:
+    def rate_limits(self) -> dict[str, dict[str, str]]:
+        rate_limits = {}
+        if os.path.exists(self.rate_limits_file):
+            with open(self.rate_limits_file) as fp:
                 rate_limits = yaml.safe_load(fp) or {}
         return rate_limits
 

--- a/cads_processing_api_service/config.py
+++ b/cads_processing_api_service/config.py
@@ -81,39 +81,41 @@ class RateLimitsMethodConfig(pydantic.BaseModel):
     """Rate limits configuration for a specific origin."""
 
     api: Annotated[list[str], pydantic.AfterValidator(validate_rate_limits)] = (
-        pydantic.Field([])
+        pydantic.Field(default=[])
     )
     ui: Annotated[list[str], pydantic.AfterValidator(validate_rate_limits)] = (
-        pydantic.Field([])
+        pydantic.Field(default=[])
     )
 
 
 class RateLimitsRouteConfig(pydantic.BaseModel):
-    post: RateLimitsMethodConfig = pydantic.Field(RateLimitsMethodConfig())
-    get: RateLimitsMethodConfig = pydantic.Field(RateLimitsMethodConfig())
-    delete: RateLimitsMethodConfig = pydantic.Field(RateLimitsMethodConfig())
+    post: RateLimitsMethodConfig = pydantic.Field(default=RateLimitsMethodConfig())
+    get: RateLimitsMethodConfig = pydantic.Field(default=RateLimitsMethodConfig())
+    delete: RateLimitsMethodConfig = pydantic.Field(default=RateLimitsMethodConfig())
 
 
 class RateLimitsConfig(pydantic.BaseModel):
     default: RateLimitsRouteConfig = pydantic.Field(
-        RateLimitsRouteConfig(), validate_default=True
+        default=RateLimitsRouteConfig(), validate_default=True
     )
     process_execution: RateLimitsRouteConfig = pydantic.Field(
-        RateLimitsRouteConfig(),
+        default=RateLimitsRouteConfig(),
         alias="processes/{process_id}/execution",
         validate_default=True,
     )
     jobs: RateLimitsRouteConfig = pydantic.Field(
-        RateLimitsRouteConfig(), alias="jobs", validate_default=True
+        default=RateLimitsRouteConfig(), alias="jobs", validate_default=True
     )
     job: RateLimitsRouteConfig = pydantic.Field(
-        RateLimitsRouteConfig(), alias="jobs/{job_id}", validate_default=True
+        default=RateLimitsRouteConfig(), alias="jobs/{job_id}", validate_default=True
     )
     job_results: RateLimitsRouteConfig = pydantic.Field(
-        RateLimitsRouteConfig(), alias="jobs/{job_id}/results", validate_default=True
+        default=RateLimitsRouteConfig(),
+        alias="jobs/{job_id}/results",
+        validate_default=True,
     )
 
-    @pydantic.model_validator(mode="after")
+    @pydantic.model_validator(mode="after")  # type: ignore
     def populate_fields_with_default(self) -> None:
         default = self.default
         if default is RateLimitsRouteConfig():
@@ -189,7 +191,7 @@ class Settings(pydantic_settings.BaseSettings):
 
     @property
     def rate_limits(self) -> RateLimitsConfig:
-        rate_limits = load_rate_limits(self.rate_limits_file)
+        rate_limits = load_rate_limits(self.rate_limits_file)  # type: ignore
         return rate_limits
 
 

--- a/cads_processing_api_service/config.py
+++ b/cads_processing_api_service/config.py
@@ -202,30 +202,28 @@ settings = Settings()
 
 def validate_download_nodes_file(download_nodes_file: str) -> pathlib.Path:
     download_nodes_file_path = pathlib.Path(download_nodes_file)
-    if not download_nodes_file_path.exists():
-        raise FileNotFoundError(
-            f"Download nodes file not found: {download_nodes_file_path}"
-        )
-    try:
-        with open(download_nodes_file_path, "r") as file:
-            lines = file.readlines()
-            line_count = len(lines)
-            if line_count == 0:
-                raise ValueError("Download nodes file is empty")
-    except Exception as e:
-        raise ValueError(
-            f"Failed to read download nodes file: {download_nodes_file_path}"
-        ) from e
+    _ = load_download_nodes(download_nodes_file_path)
     return download_nodes_file_path
 
 
 @functools.lru_cache
 def load_download_nodes(download_nodes_file: pathlib.Path) -> list[str]:
     download_nodes = []
-    with open(download_nodes_file, "r") as file:
-        for line in file:
-            if download_node := os.path.expandvars(line.rstrip("\n")):
-                download_nodes.append(download_node)
+    if not download_nodes_file.exists():
+        raise FileNotFoundError(f"Download nodes file not found: {download_nodes_file}")
+    try:
+        with open(download_nodes_file, "r") as file:
+            for line in file:
+                if download_node := os.path.expandvars(line.rstrip("\n")):
+                    download_nodes.append(download_node)
+    except Exception as e:
+        raise ValueError(
+            f"Failed to read download nodes file: {download_nodes_file}"
+        ) from e
+    if not download_nodes:
+        raise ValueError(
+            f"No download nodes found in download nodes file: {download_nodes_file}"
+        )
     return download_nodes
 
 

--- a/cads_processing_api_service/config.py
+++ b/cads_processing_api_service/config.py
@@ -188,11 +188,13 @@ class Settings(pydantic_settings.BaseSettings):
     rate_limits_file: Annotated[
         str, pydantic.AfterValidator(validate_rate_limits_file)
     ] = "/etc/retrieve-api/rate-limits.yaml"
+    rate_limits: RateLimitsConfig = pydantic.Field(default=RateLimitsConfig())
 
-    @property
-    def rate_limits(self) -> RateLimitsConfig:
-        rate_limits = load_rate_limits(self.rate_limits_file)  # type: ignore
-        return rate_limits
+    @pydantic.model_validator(mode="after")  # type: ignore
+    def load_rate_limits(self) -> None:
+        self.rate_limits: RateLimitsConfig = load_rate_limits(
+            pathlib.Path(self.rate_limits_file)
+        )
 
 
 settings = Settings()

--- a/cads_processing_api_service/config.py
+++ b/cads_processing_api_service/config.py
@@ -191,10 +191,11 @@ class Settings(pydantic_settings.BaseSettings):
     rate_limits: RateLimitsConfig = pydantic.Field(default=RateLimitsConfig())
 
     @pydantic.model_validator(mode="after")  # type: ignore
-    def load_rate_limits(self) -> None:
+    def load_rate_limits(self) -> pydantic_settings.BaseSettings:
         self.rate_limits: RateLimitsConfig = load_rate_limits(
             pathlib.Path(self.rate_limits_file)
         )
+        return self
 
 
 settings = Settings()

--- a/cads_processing_api_service/config.py
+++ b/cads_processing_api_service/config.py
@@ -66,6 +66,9 @@ MISSING_LICENCES_MESSAGE = (
     "to accept the required licence(s)."
 )
 
+RATE_LIMITS_STORAGE = limits.storage.MemoryStorage()
+RATE_LIMITS_LIMITER = limits.strategies.FixedWindowRateLimiter(RATE_LIMITS_STORAGE)
+
 
 def validate_rate_limits(rate_limits: list[str]) -> list[str]:
     """Validate rate limits configuration."""

--- a/cads_processing_api_service/config.py
+++ b/cads_processing_api_service/config.py
@@ -162,7 +162,7 @@ class Settings(pydantic_settings.BaseSettings):
 
     allow_cors: bool = True
 
-    default__control: str = "max-age=2"
+    default_cache_control: str = "max-age=2"
     default_vary: str = "PRIVATE-TOKEN, Authorization"
     public_cache_control: str = "public, max-age=60"
     portal_header_name: str = "X-CADS-PORTAL"

--- a/cads_processing_api_service/limits.py
+++ b/cads_processing_api_service/limits.py
@@ -28,7 +28,7 @@ limiter = config.RATE_LIMITS_LIMITER
 
 
 def check_rate_limits_for_user(
-    user_uid: str, rate_limits: limits.RateLimitItem
+    user_uid: str, rate_limits: list[limits.RateLimitItem]
 ) -> None:
     rate_limits_exceeded = [
         rate_limit

--- a/cads_processing_api_service/limits.py
+++ b/cads_processing_api_service/limits.py
@@ -23,8 +23,8 @@ SETTINGS = config.settings
 
 logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
 
-storage = limits.storage.MemoryStorage()
-limiter = limits.strategies.FixedWindowRateLimiter(storage)
+storage = config.RATE_LIMITS_STORAGE
+limiter = config.RATE_LIMITS_LIMITER
 
 
 def check_rate_limit(method: str, auth_info: models.AuthInfo) -> None:

--- a/cads_processing_api_service/limits.py
+++ b/cads_processing_api_service/limits.py
@@ -1,7 +1,25 @@
+"""CADS Processing API rate limits."""
+
+# Copyright 2022, European Union.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
 import limits
 import structlog
 
 from . import config, exceptions, models
+
+SETTINGS = config.settings
 
 logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
 
@@ -10,9 +28,7 @@ limiter = limits.strategies.FixedWindowRateLimiter(storage)
 
 
 def check_rate_limit(method: str, auth_info: models.AuthInfo) -> None:
-    rate_limits_config: dict[str, list[str]] = config.ensure_settings().rate_limits.get(
-        method, {}
-    )
+    rate_limits_config: dict[str, list[str]] = SETTINGS.rate_limits.get(method, {})
     rate_limit_ids: list[str] = rate_limits_config.get(auth_info.request_origin, [])
     rate_limits = [limits.parse(rate_limit_id) for rate_limit_id in rate_limit_ids]
     rate_limits_exceeded = [

--- a/cads_processing_api_service/limits.py
+++ b/cads_processing_api_service/limits.py
@@ -1,0 +1,5 @@
+import limits
+
+memory_storage = limits.storage.MemoryStorage()
+moving_window = limits.strategies.FixedWindowRateLimiter(memory_storage)
+one_per_minute = limits.parse("5/minute")

--- a/cads_processing_api_service/limits.py
+++ b/cads_processing_api_service/limits.py
@@ -60,5 +60,5 @@ def check_rate_limits(
     request_origin = auth_info.request_origin
     rate_limit_ids = getattr(method_rate_limits, request_origin)
     rate_limits = [limits.parse(rate_limit_id) for rate_limit_id in rate_limit_ids]
-    check_rate_limits_for_user(user_uid, request_origin, rate_limits)
+    check_rate_limits_for_user(user_uid, rate_limits)
     return None

--- a/cads_processing_api_service/limits.py
+++ b/cads_processing_api_service/limits.py
@@ -1,5 +1,35 @@
 import limits
+import structlog
 
-memory_storage = limits.storage.MemoryStorage()
-moving_window = limits.strategies.FixedWindowRateLimiter(memory_storage)
-one_per_minute = limits.parse("5/minute")
+from . import config, exceptions, models
+
+logger: structlog.stdlib.BoundLogger = structlog.get_logger(__name__)
+
+storage = limits.storage.MemoryStorage()
+limiter = limits.strategies.FixedWindowRateLimiter(storage)
+
+
+def check_rate_limit(method: str, auth_info: models.AuthInfo) -> None:
+    rate_limits_config: dict[str, list[str]] = config.ensure_settings().rate_limits.get(
+        method, {}
+    )
+    rate_limit_ids: list[str] = rate_limits_config.get(auth_info.request_origin, [])
+    rate_limits = [limits.parse(rate_limit_id) for rate_limit_id in rate_limit_ids]
+    rate_limits_exceeded = [
+        rate_limit
+        for rate_limit in rate_limits
+        if not limiter.hit(rate_limit, auth_info.user_uid)
+    ]
+    if rate_limits_exceeded:
+        rate_limiters_reset_time = [
+            limiter.get_window_stats(rate_limit, auth_info.user_uid).reset_time
+            for rate_limit in rate_limits_exceeded
+        ]
+        expiry = storage.get_expiry(auth_info.user_uid)
+        time_to_wait = max(
+            [reset_time - expiry for reset_time in rate_limiters_reset_time]
+        )
+        raise exceptions.RateLimitExceeded(
+            detail=f"Rate limit exceeded. Please wait {time_to_wait} seconds.",
+            retry_after=time_to_wait,
+        )

--- a/cads_processing_api_service/models.py
+++ b/cads_processing_api_service/models.py
@@ -23,10 +23,10 @@ import pydantic
 
 
 class AuthInfo(pydantic.BaseModel):
-    user_uid: str | None = None
+    user_uid: str
     user_role: str | None = None
-    request_origin: str | None = None
-    auth_header: tuple[str, str] | None = None
+    request_origin: str
+    auth_header: tuple[str, str]
     portal_header: str | None = None
 
 

--- a/cads_processing_api_service/models.py
+++ b/cads_processing_api_service/models.py
@@ -25,6 +25,7 @@ import pydantic
 class AuthInfo(pydantic.BaseModel):
     user_uid: str | None = None
     user_role: str | None = None
+    request_origin: str | None = None
     auth_header: tuple[str, str] | None = None
     portal_header: str | None = None
 

--- a/cads_processing_api_service/models.py
+++ b/cads_processing_api_service/models.py
@@ -22,6 +22,13 @@ import ogc_api_processes_fastapi.models
 import pydantic
 
 
+class AuthInfo(pydantic.BaseModel):
+    user_uid: str | None = None
+    user_role: str | None = None
+    auth_header: tuple[str, str] | None = None
+    portal_header: tuple[str, str] | None = None
+
+
 class StatusCode(str, enum.Enum):
     accepted: str = "accepted"
     running: str = "running"

--- a/cads_processing_api_service/models.py
+++ b/cads_processing_api_service/models.py
@@ -26,7 +26,7 @@ class AuthInfo(pydantic.BaseModel):
     user_uid: str | None = None
     user_role: str | None = None
     auth_header: tuple[str, str] | None = None
-    portal_header: tuple[str, str] | None = None
+    portal_header: str | None = None
 
 
 class StatusCode(str, enum.Enum):

--- a/environment.yml
+++ b/environment.yml
@@ -20,3 +20,5 @@ dependencies:
 - starlette-exporter
 - structlog
 - uvicorn>=0.26.0
+- pip:
+  - limits

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "cads-catalogue@git+https://github.com/ecmwf-projects/cads-catalogue.git",
   "cads-common@git+https://github.com/ecmwf-projects/cads-common.git",
   "fastapi",
+  "limits",
   "ogc-api-processes-fastapi@git+https://github.com/ecmwf-projects/ogc-api-processes-fastapi.git",
   "pydantic>2",
   "pydantic-settings>2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,8 @@ strict = true
 ignore_missing_imports = true
 module = [
   "cads_adaptors.*",
-  "cads_common.*"
+  "cads_common.*",
+  "yaml"
 ]
 
 [tool.ruff]

--- a/tests/test_10_config.py
+++ b/tests/test_10_config.py
@@ -67,7 +67,7 @@ def test_validate_rate_limits() -> None:
 
 
 def test_load_rate_limits(tmp_path: pathlib.Path) -> None:
-    rate_limits_file = tmp_path / "rate-limits.yaml"
+    rate_limits_file = str(tmp_path / "rate-limits.yaml")
     rate_limits = {
         "processes/{process_id}/execution": {
             "post": {"api": ["1/second"], "ui": ["2/second"]}
@@ -78,7 +78,7 @@ def test_load_rate_limits(tmp_path: pathlib.Path) -> None:
     loaded_rate_limits = config.load_rate_limits(rate_limits_file)
     assert loaded_rate_limits == config.RateLimitsConfig(**rate_limits)
 
-    rate_limits_file = tmp_path / "not-found-rate-limits.yaml"
+    rate_limits_file = str(tmp_path / "not-found-rate-limits.yaml")
     loaded_rate_limits = config.load_rate_limits(rate_limits_file)
     assert loaded_rate_limits == config.RateLimitsConfig()
 

--- a/tests/test_10_config.py
+++ b/tests/test_10_config.py
@@ -16,7 +16,6 @@
 
 import pathlib
 
-import pydantic
 import pytest
 import yaml
 
@@ -82,28 +81,6 @@ def test_load_rate_limits(tmp_path: pathlib.Path) -> None:
     rate_limits_file = tmp_path / "not-found-rate-limits.yaml"
     loaded_rate_limits = config.load_rate_limits(rate_limits_file)
     assert loaded_rate_limits == config.RateLimitsConfig()
-
-
-def test_validate_rate_limits_file(tmp_path: pathlib.Path) -> None:
-    invalid_rate_limits_file = tmp_path / "invalid-rate-limits.yaml"
-    invalid_rate_limits = {
-        "processes/{process_id}/execution": {
-            "post": {"api": ["invalid_rate_limit"], "ui": ["2/second"]}
-        },
-    }
-    with open(invalid_rate_limits_file, "w") as file:
-        yaml.dump(invalid_rate_limits, file)
-    with pytest.raises(pydantic.ValidationError):
-        _ = config.validate_rate_limits_file(invalid_rate_limits_file)
-
-    invalid_rate_limits_file = tmp_path / "invalid-rate-limits.yaml"
-    invalid_rate_limits = {
-        "default": {"post": {"api": "invalid_rate_limit"}},
-    }
-    with open(invalid_rate_limits_file, "w") as file:
-        yaml.dump(invalid_rate_limits, file)
-    with pytest.raises(pydantic.ValidationError):
-        _ = config.validate_rate_limits_file(invalid_rate_limits_file)
 
 
 def test_rate_limits_config_populate_with_default() -> None:

--- a/tests/test_10_config.py
+++ b/tests/test_10_config.py
@@ -23,17 +23,6 @@ import yaml
 from cads_processing_api_service import config
 
 
-def test_validate_download_nodes_file(tmp_path: pathlib.Path) -> None:
-    not_existing_download_nodes_file = tmp_path / "not-existing-download-nodes.config"
-    with pytest.raises(FileNotFoundError):
-        _ = config.validate_download_nodes_file(not_existing_download_nodes_file)
-
-    empty_download_nodes_file = tmp_path / "empty-download-nodes.config"
-    empty_download_nodes_file.write_text("")
-    with pytest.raises(ValueError):
-        _ = config.validate_download_nodes_file(empty_download_nodes_file)
-
-
 def test_load_download_nodes(tmp_path: pathlib.Path) -> None:
     download_nodes_file = tmp_path / "download-nodes.config"
     download_nodes_file.write_text(
@@ -46,6 +35,27 @@ def test_load_download_nodes(tmp_path: pathlib.Path) -> None:
         "http://download_node_3/",
     ]
     assert download_nodes == exp_download_nodes
+
+    not_existing_download_nodes_file = tmp_path / "not-existing-download-nodes.config"
+    with pytest.raises(FileNotFoundError):
+        _ = config.load_download_nodes(not_existing_download_nodes_file)
+
+    empty_download_nodes_file = tmp_path / "empty-download-nodes.config"
+    empty_download_nodes_file.write_text("")
+    with pytest.raises(ValueError):
+        _ = config.load_download_nodes(empty_download_nodes_file)
+
+
+def test_validate_download_nodes_file(tmp_path: pathlib.Path) -> None:
+    download_nodes_file = tmp_path / "download-nodes.config"
+    download_nodes_file.write_text(
+        "http://download_node_1/\n\nhttp://download_node_2/\nhttp://download_node_3/"
+    )
+    download_nodes_file_path = config.validate_download_nodes_file(
+        str(download_nodes_file)
+    )
+    exp_download_nodes_file_path = download_nodes_file
+    assert download_nodes_file_path == exp_download_nodes_file_path
 
 
 def test_validate_rate_limits() -> None:

--- a/tests/test_30_limits.py
+++ b/tests/test_30_limits.py
@@ -1,0 +1,47 @@
+# Copyright 2022, European Union.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# mypy: ignore-errors
+
+import limits
+import pytest
+
+import cads_processing_api_service.limits
+from cads_processing_api_service import exceptions
+
+
+def test_check_rate_limits_for_user() -> None:
+    rate_limit_ids = ["1/second"]
+    rate_limits = [limits.parse(rate_limit_id) for rate_limit_id in rate_limit_ids]
+    user_uid = "00"
+    with pytest.raises(exceptions.RateLimitExceeded):
+        for _ in range(2):
+            cads_processing_api_service.limits.check_rate_limits_for_user(
+                user_uid, rate_limits
+            )
+
+    rate_limit_ids = ["1/second", "1/minute"]
+    rate_limits = [limits.parse(rate_limit_id) for rate_limit_id in rate_limit_ids]
+    user_uid = "01"
+    with pytest.raises(exceptions.RateLimitExceeded) as exc:
+        for _ in range(2):
+            cads_processing_api_service.limits.check_rate_limits_for_user(
+                user_uid, rate_limits
+            )
+    assert exc.value.retry_after == 60
+
+    rate_limit_ids = ["2/second"]
+    rate_limits = [limits.parse(rate_limit_id) for rate_limit_id in rate_limit_ids]
+    user_uid = "02"
+    cads_processing_api_service.limits.check_rate_limits_for_user(user_uid, rate_limits)


### PR DESCRIPTION
This PR implements rate limiting for all authenticated routes.

Rate limits must be specified in a config file, whose path can be set via the env var `RATE_LIMITS_FILE`, with the following structure:
```
default:
  post: 
    api: ["1/second", "5/minute",  ...]
    ui: ...
  get:
    api: ...
    ui: ...
  delete:
    api: ...
    ui ...
processes/{process_id}/execution:
   ...
jobs:
  ....
....
```
The following rules apply:
- Rate limits (e.g. `1/second`) must be written in a notation which is accepted by the `limits` package;
- If the file is not present, a warning log is printed at app instantiation and no rate limit is set;
- If the file is present and has an invalid structure, a `pydantic.ValidationError` is raised at app instantation specifying what is wrong (https://limits.readthedocs.io/en/stable/quickstart.html#rate-limit-string-notation);
- If some fields are not set, they are automatically filled with the fields specified in `default` (if specified)
- If a rate limit is hit, a 429 response is emitted with a message specifying the waiting time and a `Retry-After` header with the waiting time in seconds.

