### PR TITLE
Add origin in job status metadata

### DIFF
--- a/cads_processing_api_service/models.py
+++ b/cads_processing_api_service/models.py
@@ -43,6 +43,7 @@ class StatusInfoMetadata(pydantic.BaseModel):
     datasetMetadata: dict[str, Any] | None = None
     qos: dict[str, Any] | None = None
     log: list[tuple[str, str]] | None = None
+    origin: str | None = None
 
 
 class StatusInfo(ogc_api_processes_fastapi.models.StatusInfo):

--- a/cads_processing_api_service/utils.py
+++ b/cads_processing_api_service/utils.py
@@ -641,14 +641,12 @@ def make_status_info(
         finished=job["finished_at"],
         updated=job["updated_at"],
     )
-    if any(
-        field is not None for field in [request, results, dataset_metadata, qos, log]
-    ):
-        status_info.metadata = models.StatusInfoMetadata(
-            request=request,
-            results=results,
-            datasetMetadata=dataset_metadata,
-            qos=qos,
-            log=log,
-        )
+    status_info.metadata = models.StatusInfoMetadata(
+        origin=job.get("origin", None),
+        request=request,
+        results=results,
+        datasetMetadata=dataset_metadata,
+        qos=qos,
+        log=log,
+    )
     return status_info

--- a/tests/test_30_utils.py
+++ b/tests/test_30_utils.py
@@ -322,6 +322,7 @@ def test_make_status_info() -> None:
         "finished_at": "2023-01-01T16:20:12.175021",
         "updated_at": "2023-01-01T16:20:12.175021",
         "request_body": {"request": {"product_type": ["reanalysis"]}},
+        "origin": "api",
     }
     status_info = utils.make_status_info(job)
     exp_status_info = models.StatusInfo(
@@ -333,5 +334,6 @@ def test_make_status_info() -> None:
         started=job["started_at"],
         finished=job["finished_at"],
         updated=job["updated_at"],
+        metadata={"origin": "api"},
     )
     assert status_info == exp_status_info


### PR DESCRIPTION
This PR adds the `origin` field to the `metadata` field of job status reponses (for `POST /processes/<process_id>/execution`, `GET /jobs` and `GET /jobs/<job_id>`).
The `origin` field can be either `api` or `ui`, indicating respectively that the job has been submitted via the Python API or via the webportal (i.e. either using authorization via `PRIVATE-TOKEN` or `Authorization` header).