### PR TITLE
Forbid execution of processes not tied to origin portal

### DIFF
--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -219,6 +219,11 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         )
         structlog.contextvars.bind_contextvars(user_uid=auth_info.user_uid)
         request_body = execution_content.model_dump()
+        portals = (
+            [p.strip() for p in auth_info.portal_header.split(",")]
+            if auth_info.portal_header
+            else None
+        )
         catalogue_sessionmaker = db_utils.get_catalogue_sessionmaker(
             db_utils.ConnectionMode.read
         )
@@ -228,6 +233,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
                 table=self.process_table,
                 session=catalogue_session,
                 load_messages=True,
+                portals=portals,
             )
         auth.verify_if_disabled(dataset.disabled_reason, auth_info.user_role)
         adaptor_properties = adaptors.get_adaptor_properties(dataset)

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -233,7 +233,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
                 table=self.process_table,
                 session=catalogue_session,
                 load_messages=True,
-                portals=portals,
+                portals=tuple(portals),
             )
         auth.verify_if_disabled(dataset.disabled_reason, auth_info.user_role)
         adaptor_properties = adaptors.get_adaptor_properties(dataset)

--- a/cads_processing_api_service/utils.py
+++ b/cads_processing_api_service/utils.py
@@ -69,6 +69,7 @@ def lookup_resource_by_id(
     table: type[cads_catalogue.database.Resource],
     session: sqlalchemy.orm.Session,
     load_messages: bool = False,
+    portals: list[str] | None = None,
 ) -> cads_catalogue.database.Resource:
     """Look for the resource identified by `id` into the Catalogue database.
 
@@ -82,6 +83,8 @@ def lookup_resource_by_id(
         Catalogue database session.
     load_messages : bool, optional
         If True, load resource messages, by default False.
+    portals: list[str] | None, optional
+        List of portal names, by default None.
 
     Returns
     -------
@@ -100,6 +103,8 @@ def lookup_resource_by_id(
     )
     if load_messages:
         statement = statement.options(sqlalchemy.orm.joinedload(table.messages))
+    if portals:
+        statement = statement.filter(table.portal.in_(portals))
     statement = statement.filter(table.resource_uid == resource_id)
     try:
         row: cads_catalogue.database.Resource = (

--- a/cads_processing_api_service/utils.py
+++ b/cads_processing_api_service/utils.py
@@ -62,14 +62,15 @@ class JobSortCriterion(str, enum.Enum):
     key=lambda resource_id,
     table,
     session,
-    load_messages=False: cachetools.keys.hashkey(resource_id, table, load_messages),
+    load_messages=False,
+    portals=None: cachetools.keys.hashkey(resource_id, table, load_messages, portals),
 )
 def lookup_resource_by_id(
     resource_id: str,
     table: type[cads_catalogue.database.Resource],
     session: sqlalchemy.orm.Session,
     load_messages: bool = False,
-    portals: list[str] | None = None,
+    portals: tuple[str] | None = None,
 ) -> cads_catalogue.database.Resource:
     """Look for the resource identified by `id` into the Catalogue database.
 
@@ -83,8 +84,8 @@ def lookup_resource_by_id(
         Catalogue database session.
     load_messages : bool, optional
         If True, load resource messages, by default False.
-    portals: list[str] | None, optional
-        List of portal names, by default None.
+    portals: tuple[str] | None, optional
+        Portals to filter resources by, by default None.
 
     Returns
     -------


### PR DESCRIPTION
This PR forbids execution of processes for datasets for which the `portal` tag does not belong to portals contained in the `X-CADS-PORTAL` requests' header.