### PR TITLE
Do not show not-live dataset messages

### DIFF
--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -301,6 +301,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
                 content=message.content,
             )
             for message in dataset.messages
+            if message.live
         ]
         url = str(request.url)
         if url.rstrip("/").endswith("execute"):


### PR DESCRIPTION
This PR filters out from the dataset messages shown in the response to `POST /execution` those for which `live==false`.