### PR TITLE
Temporary workaround for broker settings changes 

### DIFF
--- a/cads_processing_api_service/db_utils.py
+++ b/cads_processing_api_service/db_utils.py
@@ -56,10 +56,10 @@ def get_compute_sessionmaker(
         raise ValueError(f"Invalid connection mode: {str(mode)}")
     broker_engine = sqlalchemy.create_engine(
         connection_string,
-        pool_timeout=broker_settings.pool_timeout,
-        pool_recycle=broker_settings.pool_recycle,
-        pool_size=broker_settings.pool_size,
-        max_overflow=broker_settings.max_overflow,
+        pool_timeout=broker_settings.broker_pool_timeout,
+        pool_recycle=broker_settings.broker_pool_recycle,
+        pool_size=broker_settings.broker_pool_size,
+        max_overflow=broker_settings.broker_max_overflow,
     )
     return sqlalchemy.orm.sessionmaker(broker_engine)
 


### PR DESCRIPTION
This PR implements a temporary workaround for recent changes to broker settings (https://github.com/ecmwf-projects/cads-broker/commit/ad27e8e4a8004d6ee6b31ef1a417371d44f52296) which broke broker engine instantiation in the retrieve-api.