### PR TITLE
Use custom version of cachetools.TTLCache

### DIFF
--- a/cads_processing_api_service/cache.py
+++ b/cads_processing_api_service/cache.py
@@ -1,0 +1,44 @@
+"""Caching module for the CADS Processing API Service."""
+
+# Copyright 2022, European Union.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cachetools
+
+
+class TTLCache(cachetools.TTLCache):
+    def expire(self, time=None):
+        if time is None:
+            time = self.timer()
+        root = self.__root
+        curr = root.next
+        links = self.__links
+        expired = []
+        cache_delitem = cachetools.Cache.__delitem__
+        cache_getitem = cachetools.Cache.__getitem__
+        while curr is not root and not (time < curr.expires):
+            try:
+                expired_item = cache_getitem(self, curr.key)
+                expired.append((curr.key, expired_item))
+                cache_delitem(self, curr.key)
+            except KeyError:
+                pass
+            try:
+                del links[curr.key]
+            except KeyError:
+                pass
+            next = curr.next
+            curr.unlink()
+            curr = next
+        return expired

--- a/cads_processing_api_service/cache.py
+++ b/cads_processing_api_service/cache.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# mypy: ignore-errors
+
 import cachetools
 
 

--- a/cads_processing_api_service/utils.py
+++ b/cads_processing_api_service/utils.py
@@ -36,7 +36,7 @@ import sqlalchemy.orm.exc
 import sqlalchemy.sql.selectable
 import structlog
 
-from . import config, exceptions, models
+from . import cache, config, exceptions, models
 
 SETTINGS = config.settings
 
@@ -120,7 +120,7 @@ def lookup_resource_by_id(
 
 
 @cachetools.cached(
-    cache=cachetools.TTLCache(
+    cache=cache.TTLCache(
         maxsize=SETTINGS.cache_resources_maxsize,
         ttl=SETTINGS.cache_resources_ttl,
     ),


### PR DESCRIPTION
This PR implements the use of a custom version of `cachetools.TTLCache` cache for the `get_resource_properties` functions, ignoring `KeyError` when deleting expired items. This should prevents raise condition causing the issue reported in https://jira.ecmwf.int/browse/COPDS-2358.