### PR TITLE
in case of internal server error, log only the Exception Group Traceback (if present)

### DIFF
--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -382,7 +382,8 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
             List of jobs status information.
         """
         structlog.contextvars.bind_contextvars(
-            **auth_info.model_dump(), client_endpoint="get_jobs"
+            **auth_info.model_dump(),
+            client_endpoint="get_jobs",
         )
         logger.info("get_jobs")
         _ = limits.check_rate_limits(
@@ -505,7 +506,9 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
             Job status information.
         """
         structlog.contextvars.bind_contextvars(
-            **auth_info.model_dump(), job_id=job_id, client_endpoint="get_job"
+            **auth_info.model_dump(),
+            job_id=job_id,
+            client_endpoint="get_job",
         )
         logger.info("get_job")
         _ = limits.check_rate_limits(


### PR DESCRIPTION
I noticed that what makes tracebacks very long (making Splunk not parsing them correctly) is the fact that, sometimes (up until now only observed with the `general_exception_handler`, so for `500` responses), the traceback extracted from the esception include bot the section `Exception Group Traceback` and the normal traceback. As information looks (at least in the examined cases) repeated in the two sections, with this PR the processing API only add the `Exception Group Traceback` section to the logs for `500` responses, thus reducing the overall length of the log entry.