### PR TITLE
Reduce tracebacks length in logs

### DIFF
--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -234,7 +234,6 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
             if auth_info.portal_header
             else None
         )
-        raise KeyError("auth_info")
         catalogue_sessionmaker = db_utils.get_catalogue_sessionmaker(
             db_utils.ConnectionMode.read
         )

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -83,6 +83,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         "DeleteJob": "Dismiss the job identifed by `job_id`.",
     }
 
+    @exceptions.exception_logger
     def get_processes(
         self,
         limit: int | None = fastapi.Query(10, ge=1, le=10000),
@@ -139,6 +140,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         process_list._pagination_query_params = pagination_query_params
         return process_list
 
+    @exceptions.exception_logger
     def get_process(
         self,
         response: fastapi.Response,
@@ -188,6 +190,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
 
         return process_description
 
+    @exceptions.exception_logger
     def post_process_execution(
         self,
         request: fastapi.Request,
@@ -231,6 +234,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
             if auth_info.portal_header
             else None
         )
+        raise KeyError("auth_info")
         catalogue_sessionmaker = db_utils.get_catalogue_sessionmaker(
             db_utils.ConnectionMode.read
         )
@@ -327,6 +331,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         status_info.message = job_message
         return status_info
 
+    @exceptions.exception_logger
     def get_jobs(
         self,
         processID: list[str] | None = fastapi.Query(None),
@@ -460,6 +465,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
 
         return job_list
 
+    @exceptions.exception_logger
     def get_job(
         self,
         job_id: str = fastapi.Path(...),
@@ -594,6 +600,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         status_info = utils.make_status_info(job=job, **kwargs)
         return status_info
 
+    @exceptions.exception_logger
     def get_job_results(
         self,
         job_id: str = fastapi.Path(...),
@@ -656,6 +663,7 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
         handle_download_metrics(job.process_id, results)
         return results
 
+    @exceptions.exception_logger
     def delete_job(
         self,
         job_id: str = fastapi.Path(...),

--- a/cads_processing_api_service/constraints.py
+++ b/cads_processing_api_service/constraints.py
@@ -9,6 +9,7 @@ import fastapi
 from . import adaptors, db_utils, exceptions, models, utils
 
 
+@exceptions.exception_logger
 def apply_constraints(
     process_id: str = fastapi.Path(...),
     execution_content: models.Execute = fastapi.Body(...),

--- a/cads_processing_api_service/costing.py
+++ b/cads_processing_api_service/costing.py
@@ -22,7 +22,7 @@ import cads_adaptors.exceptions
 import cads_catalogue
 import fastapi
 
-from . import adaptors, costing, db_utils, models, utils
+from . import adaptors, costing, db_utils, exceptions, models, utils
 
 COST_THRESHOLDS = {"api": "max_costs", "ui": "max_costs_portal"}
 
@@ -32,6 +32,7 @@ class RequestOrigin(str, enum.Enum):
     ui = "ui"
 
 
+@exceptions.exception_logger
 def estimate_cost(
     process_id: str = fastapi.Path(...),
     request_origin: RequestOrigin = fastapi.Query("api"),

--- a/cads_processing_api_service/exceptions.py
+++ b/cads_processing_api_service/exceptions.py
@@ -16,6 +16,7 @@
 
 import functools
 import traceback
+from typing import Any, Callable
 
 import attrs
 import fastapi
@@ -64,9 +65,9 @@ class RateLimitExceeded(ogc_api_processes_fastapi.exceptions.OGCAPIException):
     retry_after: int = 0
 
 
-def exception_logger(f):
+def exception_logger(f: Callable[..., Any]) -> Callable[..., Any]:
     @functools.wraps(f)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
         try:
             res = f(*args, **kwargs)
         except requests.exceptions.ReadTimeout:

--- a/cads_processing_api_service/translators.py
+++ b/cads_processing_api_service/translators.py
@@ -20,7 +20,7 @@ from typing import Any
 import fastapi
 import structlog
 
-from . import config
+from . import config, exceptions
 
 SETTINGS = config.settings
 
@@ -335,6 +335,7 @@ def format_api_request(
     return api_request
 
 
+@exceptions.exception_logger
 def get_api_request(
     process_id: str = fastapi.Path(...),
     request: dict[str, Any] = fastapi.Body(...),


### PR DESCRIPTION
This PR aims at reducing the length of tracebacks in logs, as too long log messages are not correctly treated (i.e. parsed) by Splunk. In general, the excessive length of tracebacks is also due to repeated context information regarding fastapi and starlette internal code, which is not useful for debugging purposes.
This PR address this issue by logging exceptions not at fastapi exception handler but before, through a logging decorator wrapping the client's endpoints.