### PR TITLE
Update costing response

### DIFF
--- a/cads_processing_api_service/costing.py
+++ b/cads_processing_api_service/costing.py
@@ -75,7 +75,7 @@ def estimate_cost(
     if costing_info.cost_bar_steps:
         cost.cost_bar_steps = costing_info.cost_bar_steps
     try:
-        _ = check_request_validity(
+        check_request_validity(
             request=request,
             request_origin=request_origin,
             mandatory_inputs=mandatory_inputs,

--- a/cads_processing_api_service/costing.py
+++ b/cads_processing_api_service/costing.py
@@ -68,24 +68,31 @@ def estimate_cost(
             portals=portals,
         )
     adaptor_properties = adaptors.get_adaptor_properties(dataset)
-    request_is_valid = check_request_validity(
-        request=request,
-        mandatory_inputs=mandatory_inputs,
-        adaptor_properties=adaptor_properties,
-    )
     costing_info = compute_costing(
         request.get("inputs", {}), adaptor_properties, request_origin
     )
     cost = compute_highest_cost_limit_ratio(costing_info)
     if costing_info.cost_bar_steps:
         cost.cost_bar_steps = costing_info.cost_bar_steps
-    costing_info.request_is_valid = request_is_valid
+    try:
+        _ = check_request_validity(
+            request=request,
+            request_origin=request_origin,
+            mandatory_inputs=mandatory_inputs,
+            adaptor_properties=adaptor_properties,
+        )
+    except exceptions.InvalidRequest as exc:
+        cost.request_is_valid = False
+        cost.invalid_reason = exc.detail
     return cost
 
 
 def check_request_validity(
-    request: dict[str, Any], mandatory_inputs: bool, adaptor_properties: dict[str, Any]
-) -> bool:
+    request: dict[str, Any],
+    request_origin: RequestOrigin,
+    mandatory_inputs: bool,
+    adaptor_properties: dict[str, Any],
+) -> None:
     """
     Check if the request is valid.
 
@@ -93,6 +100,8 @@ def check_request_validity(
     ----------
     request : dict[str, Any]
         Request to be processed.
+    request_origin : RequestOrigin
+        Origin of the request.
     mandatory_inputs : bool
         Whether mandatory inputs have been provided.
     adaptor_properties : dict[str, Any]
@@ -100,17 +109,21 @@ def check_request_validity(
 
     Returns
     -------
-    bool
-        Whether the request is valid.
+    None
+
+    Raises
+    ------
+    exceptions.InvalidRequest
+        If the request is invalid.
     """
-    if not mandatory_inputs:
-        return False
+    if not mandatory_inputs and request_origin == RequestOrigin.ui:
+        raise exceptions.InvalidRequest("missing mandatory inputs")
     try:
         adaptor = adaptors.instantiate_adaptor(adaptor_properties=adaptor_properties)
         _ = adaptor.check_validity(request.get("inputs", {}))
-        return True
-    except cads_adaptors.exceptions.InvalidRequest:
-        return False
+        return
+    except cads_adaptors.exceptions.InvalidRequest as exc:
+        raise exceptions.InvalidRequest(str(exc))
 
 
 def compute_highest_cost_limit_ratio(
@@ -173,7 +186,9 @@ def compute_costing(
     )
     costing_config: dict[str, Any] = adaptor_properties["config"].get("costing", {})
     limits: dict[str, Any] = costing_config.get("max_costs", {})
-    cost_bar_steps = costing_config.get("cost_bar_steps", None)
+    cost_bar_steps = (
+        costing_config.get("cost_bar_steps", None) if request_origin == "ui" else None
+    )
     costing_info = models.CostingInfo(
         costs=costs, limits=limits, cost_bar_steps=cost_bar_steps
     )

--- a/cads_processing_api_service/main.py
+++ b/cads_processing_api_service/main.py
@@ -86,6 +86,7 @@ app.router.add_api_route(
     costing.estimate_cost,
     description="Estimate costs of the submitted process execution.",
     methods=["POST"],
+    response_model_exclude_unset=True,
 )
 app.router.add_api_route(
     "/processes/{process_id}/api-request",

--- a/cads_processing_api_service/models.py
+++ b/cads_processing_api_service/models.py
@@ -81,7 +81,6 @@ class CostingInfo(pydantic.BaseModel):
     costs: dict[str, float] = {}
     limits: dict[str, float] = {}
     cost_bar_steps: list[int] | None = None
-    request_is_valid: bool = True
 
 
 class RequestCost(pydantic.BaseModel):
@@ -89,6 +88,8 @@ class RequestCost(pydantic.BaseModel):
     cost: float = 0.0
     limit: float = 1.0
     cost_bar_steps: list[int] | None = None
+    request_is_valid: bool = True
+    invalid_reason: str | None = None
 
 
 class Execute(ogc_api_processes_fastapi.models.Execute):


### PR DESCRIPTION
This PR updates `/costing` response. It
- add `request_is_valid` and `invalid_request` fields;
- enable `cost_bar_steps` only for requests with `request_origin` query parameter set to `ui`.