### PR TITLE
Allow for str type costs

### DIFF
--- a/cads_processing_api_service/auth.py
+++ b/cads_processing_api_service/auth.py
@@ -341,7 +341,7 @@ def verify_if_disabled(disabled_reason: str | None, user_role: str | None) -> No
 
 def verify_cost(
     request: dict[str, Any], adaptor_properties: dict[str, Any], request_origin: str
-) -> dict[str, float] | None:
+) -> dict[str, float | str] | None:
     """Verify if the cost of a process execution request is within the allowed limits.
 
     Parameters

--- a/cads_processing_api_service/costing.py
+++ b/cads_processing_api_service/costing.py
@@ -184,17 +184,12 @@ def compute_costing(
     costs: dict[str, Any] = adaptor.estimate_costs(
         request=request, cost_threshold=cost_threshold
     )
-    costs_numeric = {
-        cost_id: cost
-        for cost_id, cost in costs.items()
-        if isinstance(cost, (int, float))
-    }
     costing_config: dict[str, Any] = adaptor_properties["config"].get("costing", {})
     limits: dict[str, Any] = costing_config.get("max_costs", {})
     cost_bar_steps = (
         costing_config.get("cost_bar_steps", None) if request_origin == "ui" else None
     )
     costing_info = models.CostingInfo(
-        costs=costs_numeric, limits=limits, cost_bar_steps=cost_bar_steps
+        costs=costs, limits=limits, cost_bar_steps=cost_bar_steps
     )
     return costing_info

--- a/cads_processing_api_service/costing.py
+++ b/cads_processing_api_service/costing.py
@@ -143,11 +143,16 @@ def compute_highest_cost_limit_ratio(
         Info on the cost with the highest cost/limit ratio.
     """
     costs = costing_info.costs
+    costs_numeric = {
+        cost_id: cost
+        for cost_id, cost in costs.items()
+        if isinstance(cost, (int, float))
+    }
     limits = costing_info.limits
     highest_cost_limit_ratio = 0.0
     highest_cost = models.RequestCost()
     for limit_id, limit in limits.items():
-        cost = costs.get(limit_id, 0.0)
+        cost = costs_numeric.get(limit_id, 0.0)
         cost_limit_ratio = cost / limit if limit > 0 else 1.1
         if cost_limit_ratio > highest_cost_limit_ratio:
             highest_cost_limit_ratio = cost_limit_ratio

--- a/cads_processing_api_service/models.py
+++ b/cads_processing_api_service/models.py
@@ -78,7 +78,7 @@ class Exception(ogc_api_processes_fastapi.models.Exception):
 
 
 class CostingInfo(pydantic.BaseModel):
-    costs: dict[str, float] = {}
+    costs: dict[str, float | str] = {}
     limits: dict[str, float] = {}
     cost_bar_steps: list[int] | None = None
 


### PR DESCRIPTION
This PR allow for `str` type costs, removing filtering out of those costs introduced in https://github.com/ecmwf-projects/cads-processing-api-service/pull/245. This is due because `str` type costs needs to be forwarded to the broker.