### PR TITLE
Add dataset's catalogue to job status info

### DIFF
--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -23,7 +23,6 @@ import attrs
 import cacholote.extra_encoders
 import cads_adaptors.exceptions
 import cads_broker.database
-import cads_catalogue.config
 import cads_catalogue.database
 import fastapi
 import ogc_api_processes_fastapi
@@ -31,11 +30,6 @@ import ogc_api_processes_fastapi.clients
 import ogc_api_processes_fastapi.exceptions
 import ogc_api_processes_fastapi.models
 import sqlalchemy
-import sqlalchemy.orm
-import sqlalchemy.orm.attributes
-import sqlalchemy.orm.decl_api
-import sqlalchemy.orm.exc
-import sqlalchemy.sql.selectable
 import structlog
 
 from . import (

--- a/cads_processing_api_service/clients.py
+++ b/cads_processing_api_service/clients.py
@@ -445,7 +445,10 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
                     utils.make_status_info(
                         job=job,
                         results=results,
-                        dataset_metadata={"title": dataset_title},
+                        dataset_metadata={
+                            "title": dataset_title,
+                            "catalogue": job.portal,
+                        },
                         qos={
                             "status": cads_broker.database.get_qos_status_from_request(
                                 job
@@ -601,7 +604,9 @@ class DatabaseClient(ogc_api_processes_fastapi.clients.BaseClient):
             kwargs["qos"] = {
                 **job_qos_info,
             }
-        status_info = utils.make_status_info(job=job, **kwargs)
+        status_info = utils.make_status_info(
+            job=job, dataset_metadata={"catalogue": job.portal}, **kwargs
+        )
         return status_info
 
     @exceptions.exception_logger

--- a/cads_processing_api_service/constraints.py
+++ b/cads_processing_api_service/constraints.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 import cads_adaptors
-import cads_adaptors.constraints
 import cads_adaptors.exceptions
 import cads_catalogue
 import fastapi

--- a/cads_processing_api_service/db_utils.py
+++ b/cads_processing_api_service/db_utils.py
@@ -18,7 +18,7 @@ import enum
 import functools
 
 import cads_broker.config
-import cads_catalogue.config
+import cads_catalogue.database
 import sqlalchemy
 import sqlalchemy.orm
 

--- a/cads_processing_api_service/utils.py
+++ b/cads_processing_api_service/utils.py
@@ -32,7 +32,6 @@ import sqlalchemy as sa
 import sqlalchemy.exc
 import sqlalchemy.orm
 import sqlalchemy.orm.attributes
-import sqlalchemy.orm.exc
 import sqlalchemy.sql.selectable
 import structlog
 


### PR DESCRIPTION
This PR adds the `portal` field of the requested dataset to the jobs' status info, in both the `/jobs/<job_id>` and `/jobs` responses. The field is added to the field
```
{
   ...
   "datasetMetadata": {"catalogue": <portal>},
   ...
}
```