### PR TITLE
Fix cachetools race conditions

### DIFF
--- a/cads_processing_api_service/auth.py
+++ b/cads_processing_api_service/auth.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import threading
 import urllib.parse
 from typing import Any
 
@@ -91,6 +92,7 @@ def authenticate_user(
         maxsize=SETTINGS.cache_users_maxsize,
         ttl=SETTINGS.cache_users_ttl,
     ),
+    lock=threading.Lock(),
 )
 def get_user_info(
     auth_header: tuple[str, str] | None,

--- a/cads_processing_api_service/utils.py
+++ b/cads_processing_api_service/utils.py
@@ -123,6 +123,7 @@ def lookup_resource_by_id(
         maxsize=SETTINGS.cache_resources_maxsize,
         ttl=SETTINGS.cache_resources_ttl,
     ),
+    lock=threading.Lock(),
     key=lambda resource_id, table, properties, session: cachetools.keys.hashkey(
         resource_id, table, properties
     ),


### PR DESCRIPTION
This PR implements a tentative fix for the race conditions causing flares of Internal Server Errors on retrieve-api pods.